### PR TITLE
BUILD-3093 Setup a GitHub action to enforce pre-commit at CI level

### DIFF
--- a/.github/tests/resources/fail-check/.pre-commit-config.yaml
+++ b/.github/tests/resources/fail-check/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.5.0
+      hooks:
+        -   id: check-json
+            files: ".github/tests/resources/fail-check/wrong.json"

--- a/.github/tests/resources/fail-check/wrong.json
+++ b/.github/tests/resources/fail-check/wrong.json
@@ -1,0 +1,6 @@
+some:
+  content:
+    - which
+    - is
+    - not
+    - json

--- a/.github/tests/resources/success-check/.pre-commit-config.yaml
+++ b/.github/tests/resources/success-check/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.5.0
+      hooks:
+        -   id: check-json
+            files: ".github/tests/resources/success-check/valid.json"

--- a/.github/tests/resources/success-check/valid.json
+++ b/.github/tests/resources/success-check/valid.json
@@ -1,0 +1,10 @@
+{
+  "some": {
+    "content": [
+      "which",
+      "is",
+      "correct",
+      "json"
+    ]
+  }
+}

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -1,0 +1,131 @@
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+
+  it-tests-use-input-default-values:
+    name: "IT Test - default inputs values should work fine on this repo"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Given the gh-action is used with default values
+        id: test-data
+        uses: ./
+      - uses: nick-fields/assert-action@v2
+        name: Then outputs.status value must be 0 as the project itself make use of pre-commit validation
+        with:
+          expected: 0
+          actual: ${{ steps.test-data.outputs.status }}
+          comparison: exact
+
+  it-tests-use-input-extra-args:
+    name: "IT Test - custom extra-args should be honored"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Given the gh-action is used with extra-args=--help
+        id: test-data
+        uses: ./
+        with:
+          extra-args: --help
+      - uses: nick-fields/assert-action@v2
+        name: Then outputs.logs should contains some printed documentation
+        with:
+          expected: "usage: pre-commit run"
+          actual: ${{ steps.test-data.outputs.logs }}
+          comparison: contains
+
+  it-tests-output-status-failure:
+    name: "IT Test - output status should be 1 given pre-commit detected some issue"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Given a pre-commit-config not correctly respected
+        id: test-data
+        uses: ./
+        with:
+          extra-args: '--all-files'
+          config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
+          ignore-failure: 'true'
+      - uses: nick-fields/assert-action@v2
+        name: Then outputs.status value must be 1 as there are some errors
+        with:
+          expected: 1
+          actual: ${{ steps.test-data.outputs.status }}
+          comparison: exact
+
+  it-tests-output-status-success:
+    name: "IT Test - output status should be 0 given pre-commit detected no issue"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Given a pre-commit-config correctly respected
+        id: test-data
+        uses: ./
+        with:
+          extra-args: '--all-files'
+          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
+          ignore-failure: 'true'
+      - uses: nick-fields/assert-action@v2
+        name: Then outputs.status value must be 0 as there are no errors
+        with:
+          expected: 0
+          actual: ${{ steps.test-data.outputs.status }}
+          comparison: exact
+
+  it-tests-output-logs-failure:
+    name: "IT Test - output logs should contains failures given pre-commit detected some issue"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Given a pre-commit-config not correctly respected
+        id: test-data
+        uses: ./
+        with:
+          extra-args: '--all-files'
+          config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
+          ignore-failure: 'true'
+      - uses: nick-fields/assert-action@v2
+        name: Then it has to contains the failure message in the outputs.logs
+        with:
+          expected: "Failed"
+          actual: ${{ steps.test-data.outputs.logs }}
+          comparison: contains
+
+  it-tests-output-logs-success:
+    name: "IT Test - output logs should contains no failure given pre-commit detected no issue"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Given a pre-commit-config correctly respected
+        id: test-data
+        uses: ./
+        with:
+          extra-args: '--all-files'
+          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
+          ignore-failure: 'true'
+      - uses: nick-fields/assert-action@v2
+        name: Then it should not contain any 'Failed' in the outputs.logs
+        with:
+          expected: "Failed"
+          actual: ${{ steps.test-data.outputs.logs }}
+          comparison: notContains
+
+  it-tests:
+    name: "All IT Tests have to pass"
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      # Add your tests here so that they prevent merge of broken changes
+      - it-tests-use-input-default-values
+      - it-tests-use-input-extra-args
+      - it-tests-output-status-failure
+      - it-tests-output-status-success
+      - it-tests-output-logs-failure
+      - it-tests-output-logs-success
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@feature/svermeille/BUILD-3093-Provide-a-reusable-way-at-CI-level-to-enforce-pre-commits-in-the-organization #TODO: ref tag 0.0.1 after merge
+        with:
+          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013:
+  line_length: 120
+  tables: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9  # frozen: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 20447075e31543a8b125f2df18d75f3b5e7d4d2e  # frozen: 0.22.0
+    hooks:
+      - id: check-github-actions
+        files: .*/action.ya?ml
+      - id: check-github-workflows
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: 5341f388c2a962d3bc66e075f00b80ab45b15f24 # v0.1.20
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: c9ea83146232fb263effdfe6f222d87f5395b27a # v0.39.0
+    hooks:
+      - id: markdownlint
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 32ee411cf36142e6082f10870ae62172ce9af133  # frozen: 35.32.0
+    hooks:
+      - id: renovate-config-validator

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,31 @@
+# Developer notes
+
+> You want to contribute to this project ? Please read the following
+
+## IT Tests
+
+This project define integrations tests in `.github/workflows/it-test.yml`.
+
+Test assertions are done using [nick-fields/assert-action](https://github.com/nick-fields/assert-action).
+
+Resources used for tests are placed within `.github/tests/resources/` directory
+
+### Side note
+
+At the moment, GitHub branch protection do not allow to define checks based
+on a REGEX as we can find in other CI tools such as Jenkins.
+
+In order to work around this limitation this project make
+use of [re-actors/alls-green](https://github.com/re-actors/alls-green).
+
+All tests have to be declared in `.github/workflows/it-test.yml`
+the job called `it-tests` declares a list of needs:
+
+```yaml
+    ...
+    needs:
+       ...
+      - it-tests-output-logs-failure
+      - it-tests-output-logs-success
+      - < your new test > <-------------- Add your tests here
+```

--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ jobs:
 This project is using [Semantic Versioning](https://semver.org/).
 
 The `master` branch shall not be referenced by end-users,
-please use tags instead and Renovate to stay up to date.
-
-See [GitHub: Using tags for release management](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management)
-and [GitHub: Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot)
+please use tags instead and [Renovate](https://docs.renovatebot.com/) or
+[Dependabot](https://docs.github.com/en/code-security/dependabot) to stay up to date.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
-# gh-action_pre-commit
-Run pre-commit hooks at CI level
+# SonarSource GitHub Action for pre-commit
+
+![GitHub Release](https://img.shields.io/github/v/release/SonarSource/gh-action_pre-commit)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SonarSource_gh-action_pre-commit&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SonarSource_gh-action_pre-commit)
+[![.github/workflows/it-test.yml](https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml/badge.svg)](https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml)
+
+Run [pre-commit](https://pre-commit.com/) hooks at CI level
+
+## Usage
+
+### enforce pre-commit only to files changed within a pull request
+
+Place a `.pre-commit-config.yaml` at the root of your project
+
+Create a new GitHub workflow:
+
+```yaml
+# .github/workflows/pre-commit.yml
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last tag
+        with:
+          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} \
+            --to-ref=${{ github.event.pull_request.head.sha }}
+```
+
+> Notice: the extra-args parameter defined upper ensure that only files changed within the PR are checked by pre-commit.
+> If you rather like to ensure that **all files** are valid, then use `extra-args: --all-files` instead.
+
+## Options
+
+| Option name     | Description                                                        | Default                   |
+|-----------------|--------------------------------------------------------------------|---------------------------|
+| `config-path`   | Used to specify a custom path to a given `.pre-commit-config.yaml` | `.pre-commit-config.yaml` |
+| `extra-args`    | Used to pass extra pre-commit args to the pre-commit run command   | -                         |
+| `ignore-failure` | Used to not fail the gh-action in case of pre-commit check failure | `false`                    |
+
+## Versioning
+
+This project is using [Semantic Versioning](https://semver.org/).
+
+The `master` branch shall not be referenced by end-users,
+please use tags instead and Renovate to stay up to date.
+
+See [GitHub: Using tags for release management](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management)
+and [GitHub: Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot)
+
+## Contribute
+
+Contributions are welcome, please have a look at [DEV.md](./DEV.md)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,29 @@ jobs:
 ```
 
 > Notice: the extra-args parameter defined upper ensure that only files changed within the PR are checked by pre-commit.
-> If you rather like to ensure that **all files** are valid, then use `extra-args: --all-files` instead.
+> If you rather like to ensure that **all files** are valid, have a look at the example below.
+
+### enforce pre-commit to all files systematically
+
+Place a `.pre-commit-config.yaml` at the root of your project
+
+Create a new GitHub workflow:
+
+```yaml
+# .github/workflows/pre-commit.yml
+on:
+  branch:
+    - master
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last tag
+        with:
+          extra-args: --all-files
+```
 
 ## Options
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,80 @@
+name: pre-commit
+description: run pre-commit checks
+inputs:
+  config-path:
+    description: Optional, specify an alternative path to a .pre-commit-config.yaml file
+    required: false
+    default: '.pre-commit-config.yaml'
+  extra-args:
+    description: extra arguments passed to pre-commit run command
+    required: false
+    default: ''
+  ignore-failure:
+    description: Optional, do not fail the gh-action in case of pre-commit check failure
+    required: false
+    default: 'false'
+outputs:
+  status:
+    description: Provide the exit code returned by pre-commit run command
+    value: ${{ steps.exec-pre-commit.outputs.status }}
+  logs:
+    description: Logs from the pre-commit run command
+    value: ${{ steps.exec-pre-commit.outputs.logs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Fetch origin
+      run: git fetch origin # avoid unknown revision or path not in the working tree when
+      # using --from-ref --to-ref feature of pre-commit
+      shell: bash
+    - id: setup_python
+      name: Setup python
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      with:
+        python-version: '3.10'
+    - name: Setup pre-commit
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --quiet pre-commit==3.6.2
+      shell: bash
+    - name: Cache installed pre-commit hooks
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pre-commit
+        key: cache-pre-commit|${{ steps.setup_python.outputs.python-version }}|${{ hashFiles(inputs.config-path) }}
+    - name: Check existence of .pre-commit-config.yaml file
+      run: |
+        if [ ! -f ${{ inputs.config-path }} ]; then
+          echo "Could not find any pre-commit configuration at the provided location: '${{ inputs.config-path }}'"
+          exit 1
+        fi
+      shell: bash
+    - id: exec-pre-commit
+      name: Execute pre-commit
+      run: |
+        set +e
+        OUTPUT=$(pre-commit run --config="${{ inputs.config-path }}" --show-diff-on-failure --color=always ${{ inputs.extra-args }})
+        STATUS=$?
+        echo "status=$(echo $STATUS)" >> "$GITHUB_OUTPUT"
+        echo "$OUTPUT" >> pre-commit-exec.log
+        {
+          echo 'logs<<EOF'
+          cat pre-commit-exec.log
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+        exit 0
+      shell: bash
+    - name: Print execution
+      run: |
+        echo "${{ steps.exec-pre-commit.outputs.logs }}"
+        echo "Exit code: ${{ steps.exec-pre-commit.outputs.status }}"
+      shell: bash
+    - name: Check status and fail if necessary
+      if: ${{ inputs.ignore-failure == 'false' && steps.exec-pre-commit.outputs.status != 0 }}
+      run: |
+        echo "::error ::pre-commit execution detected some issues"
+        exit 1
+      shell: bash


### PR DESCRIPTION
# BUILD-3093 Setup a GitHub action to enforce pre-commit at CI level

## Changes

- [x] Setup a new GitHub action responsible to evaluate pre-commit-config.yaml files with pre-commit and report any rule violation.
  That way it is possible to prevent merge of PRs not passing such requirements
- [x] Document usage in README.md
- [x] Setup and Write IT tests
- [x] Integrate SonarCloud analysis
- [x] Link some working example PRs


## How was it tested ?
* some it-tests within this repository are enabled https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml
* an internal project using it: https://github.com/SonarSource/re-ci-images/pull/476

