### PR TITLE
BUILD-4660 gh-action_pre-commit example contains an error

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,4 +8,6 @@ jobs:
     steps:
       - uses: SonarSource/gh-action_pre-commit@master
         with:
-          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}
+          extra-args: |
+            --from-ref=origin/${{ github.event.pull_request.base.ref }}
+            --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: SonarSource/gh-action_pre-commit@master
         with:
-          extra-args: |
+          extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}
             --to-ref=${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last tag
         with:
-          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}
+          extra-args: |
+            --from-ref=origin/${{ github.event.pull_request.base.ref }}
+            --to-ref=${{ github.event.pull_request.head.sha }}
 ```
 
 > Notice: the extra-args parameter defined upper ensure that only files changed within the PR are checked by pre-commit.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last tag
         with:
-          extra-args: |
+          extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}
             --to-ref=${{ github.event.pull_request.head.sha }}
 ```

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last tag
+      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last tag
         with:
-          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} \
-            --to-ref=${{ github.event.pull_request.head.sha }}
+          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}
 ```
 
 > Notice: the extra-args parameter defined upper ensure that only files changed within the PR are checked by pre-commit.


### PR DESCRIPTION
# BUILD-4660 gh-action_pre-commit example contains an error

## Changes
* Update README with a working example. As of today multiline is not supported