### PR TITLE
BUILD-4983 Upgrade pre-commit version to 3.7.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Setup pre-commit
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --quiet pre-commit==3.6.2
+        python -m pip install --quiet pre-commit==3.7.1
       shell: bash
     - name: Cache installed pre-commit hooks
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4


### PR DESCRIPTION
# BUILD-4983 Upgrade pre-commit version to 3.7.1

## Changes
*  Upgrade pre-commit version to 3.7.1
   That way we keep tech debt of this project under control

## How was it tested ?

CI integration tests pass :+1: 