### PR TITLE
BUILD-5613 Fix cache is not working effectively

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
       with:
         path: ~/.cache/pre-commit
-        key: cache-pre-commit|${{ steps.setup_python.outputs.python-version }}|${{ hashFiles(inputs.config-path) }}
+        key: cache-pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
     - name: Check existence of .pre-commit-config.yaml file
       run: |
         if [ ! -f ${{ inputs.config-path }} ]; then

--- a/action.yml
+++ b/action.yml
@@ -40,11 +40,11 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install --quiet pre-commit==3.7.1
       shell: bash
-    - name: Cache installed pre-commit hooks
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+    - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      id: restore-cache
       with:
+        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
         path: ~/.cache/pre-commit
-        key: cache-pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
     - name: Check existence of .pre-commit-config.yaml file
       run: |
         if [ ! -f ${{ inputs.config-path }} ]; then
@@ -52,6 +52,18 @@ runs:
           exit 1
         fi
       shell: bash
+    - id: setup-pre-commit-hooks
+      if: steps.restore-cache.outputs.cache-hit != 'true'
+      name: Install pre-commit dependencies
+      run: |
+        pre-commit install-hooks --config="${{ inputs.config-path }}"
+      shell: bash
+    - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      if: steps.restore-cache.outputs.cache-hit != 'true'
+      with:
+        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
+        path: ~/.cache/pre-commit
+
     - id: exec-pre-commit
       name: Execute pre-commit
       run: |

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,6 @@ runs:
       with:
         key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
         path: ~/.cache/pre-commit
-
     - id: exec-pre-commit
       name: Execute pre-commit
       run: |


### PR DESCRIPTION
## Changes

- [x] Use python path as cache key element instead of the python version

The action defines:
```
      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
      with:
        python-version: '3.10'
```
Which allow python 3.10.* -> at the moment it installs 3.10.14 but the cache key was reading `3.10` so if tomorrow it installs 3.10.15 a new cache won't be created.

For safety, the code is now using the installation dir `${{ env.pythonLocation }}` which ends by `/3.10.14/` accordingly.

- [x] Control the cache manually, that way we can cache even if pre-commit validation fails
      This makes the next execution faster even if pre-commit validation failed in the previous commit!
      
The `actions/cache` automatically restore/save cache in case of successful job. 
In the case of pre-commit, generally, it fails, and then you fix it -> the cache would never be applied as long as you don't fix the pre-commit issues. (Not useful)
      
The idea here is to take control of the cache lifecycle and save it before executing pre-commit checks. 
This way in case of failure: the next commit will benefit from the cache (My tests  showed 50% faster executions for pre-commit after the first commit.) 

## How was it tested?

On sonar-dummy: https://github.com/SonarSource/sonar-dummy/pull/307
