### PR TITLE
BUILD-6229 Remove cache feature - was using too much shared storage within GitHub org

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,11 +40,6 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install --quiet pre-commit==3.7.1
       shell: bash
-    - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      id: restore-cache
-      with:
-        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
-        path: ~/.cache/pre-commit
     - name: Check existence of .pre-commit-config.yaml file
       run: |
         if [ ! -f ${{ inputs.config-path }} ]; then
@@ -53,16 +48,10 @@ runs:
         fi
       shell: bash
     - id: setup-pre-commit-hooks
-      if: steps.restore-cache.outputs.cache-hit != 'true'
       name: Install pre-commit dependencies
       run: |
         pre-commit install-hooks --config="${{ inputs.config-path }}"
       shell: bash
-    - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      if: steps.restore-cache.outputs.cache-hit != 'true'
-      with:
-        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
-        path: ~/.cache/pre-commit
     - id: exec-pre-commit
       name: Execute pre-commit
       run: |


### PR DESCRIPTION
## Changes

* Remove caching mechanisms in order to avoid reaching GitHub limits for Shared storage