### PR TITLE
BUILD-6230 save only cache from the default branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,8 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: SonarSource/gh-action_pre-commit@master
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./
         with:
           extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,8 @@ runs:
         pre-commit install-hooks --config="${{ inputs.config-path }}"
       shell: bash
     - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      if: steps.restore-cache.outputs.cache-hit != 'true'
+      if: steps.restore-cache.outputs.cache-hit != 'true' &&
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
       with:
         key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
         path: ~/.cache/pre-commit


### PR DESCRIPTION
Tested on itself:
```
Cache restored from key: pre-commit|/opt/hostedtoolcache/Python/3.10.14/x64|677378f8db838a02d42552a4f283fef31c71b40db947de9d13685799065b0049
```