### PR TITLE
BUILD-7995 Security hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 * @sonarsource/platform-eng-xp-squad
+.github/CODEOWNERS @sonarsource/platform-eng-xp-squad

--- a/action.yml
+++ b/action.yml
@@ -78,12 +78,15 @@ runs:
         OUTPUT=$(pre-commit run --config="$CONFIG_PATH" --show-diff-on-failure --color=always "$EXTRA_ARGS")
         STATUS=$?
         echo "status=$(echo $STATUS)" >> "$GITHUB_OUTPUT"
-        echo "$OUTPUT" >> pre-commit-exec.log
-        {
-          echo 'logs<<EOF'
-          cat pre-commit-exec.log
-          echo EOF
-        } >> "$GITHUB_OUTPUT"
+        # Securely expose logs without injection risk using a unique delimiter
+        DELIM="DELIM_$(openssl rand -hex 16)"
+        # Ensure delimiter is not present in the log (extremely unlikely but loop for safety)
+        while echo "$OUTPUT" | grep -q "$DELIM"; do
+          DELIM="DELIM_$(openssl rand -hex 16)"
+        done
+        echo "logs<<$DELIM" >> "$GITHUB_OUTPUT"
+        echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+        echo "$DELIM" >> "$GITHUB_OUTPUT"
         exit 0
       shell: bash
     - name: Print execution

--- a/action.yml
+++ b/action.yml
@@ -75,12 +75,11 @@ runs:
       name: Execute pre-commit
       run: |
         set +e
-        OUTPUT=$(pre-commit run --config="$CONFIG_PATH" --show-diff-on-failure --color=always "$EXTRA_ARGS")
+        OUTPUT=$(pre-commit run --config="$CONFIG_PATH" --show-diff-on-failure --color=always $EXTRA_ARGS)
         STATUS=$?
         echo "status=$(echo $STATUS)" >> "$GITHUB_OUTPUT"
-        # Securely expose logs without injection risk using a unique delimiter
+        # Securely expose log a random delimiter
         DELIM="DELIM_$(openssl rand -hex 16)"
-        # Ensure delimiter is not present in the log (extremely unlikely but loop for safety)
         while echo "$OUTPUT" | grep -q "$DELIM"; do
           DELIM="DELIM_$(openssl rand -hex 16)"
         done

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,13 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate inputs and export
+      shell: bash
+      run: |
+        CONFIG_PATH="${{ inputs.config-path }}"
+        EXTRA_ARGS="${{ inputs.extra-args }}"
+        echo "CONFIG_PATH=$CONFIG_PATH" >> "$GITHUB_ENV"
+        echo "EXTRA_ARGS=$EXTRA_ARGS"   >> "$GITHUB_ENV"
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Fetch origin
@@ -43,12 +50,12 @@ runs:
     - uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       id: restore-cache
       with:
-        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
+        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(env.CONFIG_PATH) }}
         path: ~/.cache/pre-commit
     - name: Check existence of .pre-commit-config.yaml file
       run: |
-        if [ ! -f ${{ inputs.config-path }} ]; then
-          echo "Could not find any pre-commit configuration at the provided location: '${{ inputs.config-path }}'"
+        if [ ! -f "$CONFIG_PATH" ]; then
+          echo "Could not find any pre-commit configuration at the provided location: '$CONFIG_PATH'"
           exit 1
         fi
       shell: bash
@@ -56,19 +63,19 @@ runs:
       if: steps.restore-cache.outputs.cache-hit != 'true'
       name: Install pre-commit dependencies
       run: |
-        pre-commit install-hooks --config="${{ inputs.config-path }}"
+        pre-commit install-hooks --config="$CONFIG_PATH"
       shell: bash
     - uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       if: steps.restore-cache.outputs.cache-hit != 'true' &&
           github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
       with:
-        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(inputs.config-path) }}
+        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(env.CONFIG_PATH) }}
         path: ~/.cache/pre-commit
     - id: exec-pre-commit
       name: Execute pre-commit
       run: |
         set +e
-        OUTPUT=$(pre-commit run --config="${{ inputs.config-path }}" --show-diff-on-failure --color=always ${{ inputs.extra-args }})
+        OUTPUT=$(pre-commit run --config="$CONFIG_PATH" --show-diff-on-failure --color=always "$EXTRA_ARGS")
         STATUS=$?
         echo "status=$(echo $STATUS)" >> "$GITHUB_OUTPUT"
         echo "$OUTPUT" >> pre-commit-exec.log


### PR DESCRIPTION
- **BUILD-7995 Move inputs to environment variables instead of direct interpolation and Quote all variable usage to prevent command injection**
- **BUILD-7995 Avoid writing not trusted data to env file**
- **BUILD-7995 Fix CODEOWNERS misconfiguration - Add explicit ownership of .github/CODEOWNERS file itself**

tested with https://github.com/SonarSource/sonar-dummy/actions/runs/15910686917/job/44877865418?pr=440
