### PR TITLE
BUILD-8875: Migrate to standardized GitHub runner names

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -7,7 +7,7 @@ jobs:
 
   it-tests-use-input-default-values:
     name: "IT Test - default inputs values should work fine on this repo"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Given the gh-action is used with default values
@@ -22,7 +22,7 @@ jobs:
 
   it-tests-use-input-extra-args:
     name: "IT Test - custom extra-args should be honored"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Given the gh-action is used with extra-args=--help
@@ -39,7 +39,7 @@ jobs:
 
   it-tests-output-status-failure:
     name: "IT Test - output status should be 1 given pre-commit detected some issue"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Given a pre-commit-config not correctly respected
@@ -58,7 +58,7 @@ jobs:
 
   it-tests-output-status-success:
     name: "IT Test - output status should be 0 given pre-commit detected no issue"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Given a pre-commit-config correctly respected
@@ -77,7 +77,7 @@ jobs:
 
   it-tests-output-logs-failure:
     name: "IT Test - output logs should contain failures given pre-commit detected some issue"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Given a pre-commit-config not correctly respected
@@ -96,7 +96,7 @@ jobs:
 
   it-tests-output-logs-success:
     name: "IT Test - output logs should contain no failure given pre-commit detected no issue"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Given a pre-commit-config correctly respected
@@ -115,7 +115,7 @@ jobs:
 
   it-tests:
     name: "All IT Tests have to pass"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     if: always()
     needs:
       # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./


### PR DESCRIPTION
## GitHub Actions Runner Migration

This PR updates GitHub Actions workflows to use our new standardized runner naming convention.

### Changes
- Updates runner names in workflow files to new standardized format
- No functional changes to your CI/CD pipelines
- All existing functionality remains identical

### Runner Mappings
| Old Runner | New Runner |
|------------|------------|
| sonar-runner-large | github-ubuntu-latest-s |
| ubuntu-latest-large | github-ubuntu-latest-s |
| windows-latest-large | github-windows-latest-s |
| ubuntu-24.04-large | github-ubuntu-latest-s |
| sonar-runner-large-arm | github-ubuntu-24.04-arm-s |
| ubuntu-24.04-arm-large | github-ubuntu-24.04-arm-s |

### What You Need to Do
1. Review the changes in this PR
2. Merge when ready - no additional action required
3. Old runners will remain available during transition

### Additional Information
For more details about GitHub Actions runners and their specifications, see our [GitHub Actions Runner Documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/GitHub+Actions+Runner+-+GitHub).

This is an automated migration. Questions? Contact the **Engineering Experience squad**.
