### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -7,7 +7,7 @@ jobs:
 
   it-tests-use-input-default-values:
     name: "IT Test - default inputs values should work fine on this repo"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Given the gh-action is used with default values
@@ -22,7 +22,7 @@ jobs:
 
   it-tests-use-input-extra-args:
     name: "IT Test - custom extra-args should be honored"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Given the gh-action is used with extra-args=--help
@@ -39,7 +39,7 @@ jobs:
 
   it-tests-output-status-failure:
     name: "IT Test - output status should be 1 given pre-commit detected some issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Given a pre-commit-config not correctly respected
@@ -58,7 +58,7 @@ jobs:
 
   it-tests-output-status-success:
     name: "IT Test - output status should be 0 given pre-commit detected no issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Given a pre-commit-config correctly respected
@@ -77,7 +77,7 @@ jobs:
 
   it-tests-output-logs-failure:
     name: "IT Test - output logs should contain failures given pre-commit detected some issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Given a pre-commit-config not correctly respected
@@ -96,7 +96,7 @@ jobs:
 
   it-tests-output-logs-success:
     name: "IT Test - output logs should contain no failure given pre-commit detected no issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Given a pre-commit-config correctly respected
@@ -115,7 +115,7 @@ jobs:
 
   it-tests:
     name: "All IT Tests have to pass"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     if: always()
     needs:
       # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -7,7 +7,7 @@ jobs:
 
   it-tests-use-input-default-values:
     name: "IT Test - default inputs values should work fine on this repo"
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given the gh-action is used with default values
@@ -22,7 +22,7 @@ jobs:
 
   it-tests-use-input-extra-args:
     name: "IT Test - custom extra-args should be honored"
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given the gh-action is used with extra-args=--help
@@ -39,7 +39,7 @@ jobs:
 
   it-tests-output-status-failure:
     name: "IT Test - output status should be 1 given pre-commit detected some issue"
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config not correctly respected
@@ -58,7 +58,7 @@ jobs:
 
   it-tests-output-status-success:
     name: "IT Test - output status should be 0 given pre-commit detected no issue"
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config correctly respected
@@ -77,7 +77,7 @@ jobs:
 
   it-tests-output-logs-failure:
     name: "IT Test - output logs should contain failures given pre-commit detected some issue"
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config not correctly respected
@@ -96,7 +96,7 @@ jobs:
 
   it-tests-output-logs-success:
     name: "IT Test - output logs should contain no failure given pre-commit detected no issue"
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config correctly respected
@@ -115,7 +115,7 @@ jobs:
 
   it-tests:
     name: "All IT Tests have to pass"
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     if: always()
     needs:
       # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -7,7 +7,7 @@ jobs:
 
   it-tests-use-input-default-values:
     name: "IT Test - default inputs values should work fine on this repo"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given the gh-action is used with default values
@@ -22,7 +22,7 @@ jobs:
 
   it-tests-use-input-extra-args:
     name: "IT Test - custom extra-args should be honored"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given the gh-action is used with extra-args=--help
@@ -39,7 +39,7 @@ jobs:
 
   it-tests-output-status-failure:
     name: "IT Test - output status should be 1 given pre-commit detected some issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config not correctly respected
@@ -58,7 +58,7 @@ jobs:
 
   it-tests-output-status-success:
     name: "IT Test - output status should be 0 given pre-commit detected no issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config correctly respected
@@ -77,7 +77,7 @@ jobs:
 
   it-tests-output-logs-failure:
     name: "IT Test - output logs should contain failures given pre-commit detected some issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config not correctly respected
@@ -96,7 +96,7 @@ jobs:
 
   it-tests-output-logs-success:
     name: "IT Test - output logs should contain no failure given pre-commit detected no issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config correctly respected
@@ -115,7 +115,7 @@ jobs:
 
   it-tests:
     name: "All IT Tests have to pass"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     if: always()
     needs:
       # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,9 +4,13 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: SonarSource/ci-github-actions/config-npm@v1
       - uses: ./
         with:
           extra-args: >


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/it-test.yml`
- `.github/workflows/pre-commit.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.

----
## Summary by Gitar

- **CI infrastructure migration:**
  - Updated `runs-on` targets from `github-ubuntu-latest-s` to `sonar-xs` in `.github/workflows/it-test.yml` and `.github/workflows/pre-commit.yml`.
- **Workflow configuration:**
  - Added `SonarSource/ci-github-actions/config-npm@v1` step to the `pre-commit` job in `.github/workflows/pre-commit.yml`.

<sub>This will update automatically on new commits.</sub>