### PR TITLE
BUILD-12282: Route pre-commit pip installs through Repox

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master]
 
+permissions:
+  id-token: write # Required by config-pip for Vault OIDC authentication
+  contents: read
+
 jobs:
 
   it-tests-use-input-default-values:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,10 @@
 on:
   pull_request:
 
+permissions:
+  id-token: write # Required by config-pip for Vault OIDC authentication
+  contents: read
+
 jobs:
   pre-commit:
     name: "pre-commit"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required to configure pip with Repox
+      contents: read
     steps:
       - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last tag
         with:
@@ -50,6 +53,9 @@ jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required to configure pip with Repox
+      contents: read
     steps:
       - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last tag
         with:

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ runs:
       run: git fetch origin # avoid unknown revision or path not in the working tree when
       # using --from-ref --to-ref feature of pre-commit
       shell: bash
+    # Configure Repox before setup-python. setup-python upgrades pip as part of
+    # installation, so configuring pip afterwards would still contact PyPI.
+    - name: Configure pip with Repox
+      uses: SonarSource/ci-github-actions/config-pip@v1
     - id: setup_python
       name: Setup python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
BUILD-12282: Route pre-commit pip installs through Repox

## ⚠️ REQUIRED CALLER PERMISSIONS ⚠️

Every workflow job that consumes `SonarSource/gh-action_pre-commit` must grant `id-token: write`. This is required for the action to authenticate to Vault and configure pip with Repox.

When a consumer declares `permissions:`, it must also retain `contents: read`, because this action checks out and fetches the caller repository.

## Summary

- Configure pip with Repox before `actions/setup-python` performs its internal pip upgrade.
- Grant the action repository IT and self-pre-commit workflows the required OIDC and repository-read permissions.
- Document the caller permissions in both usage examples.

## Breaking change

- Consumers without `id-token: write` will fail Vault authentication after upgrading to the released action tag.

## Test plan

- [x] Parse the changed YAML files and assert the Repox step precedes Python setup.
- [x] Run actionlint across workflows, excluding only the repository-specific custom-runner label diagnostic.
- [x] Smoke-test the Repox pip configuration script with inert credentials.
- [ ] Confirm the PR integration workflow configures Repox, upgrades pip, and completes pre-commit on an Eng XP runner.

## Follow-up

- Release a new action tag after CI passes, then update the `re-terraform-aws-vault` pin. Renovate can update the remaining consumers, subject to the required permissions above.