### PR TITLE
BUILD-12332 Disable virtualenv periodic seed updates

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Given the gh-action is used with default values
         id: test-data
         uses: ./
+      - name: Then virtualenv periodic updates are disabled
+        run: test "$VIRTUALENV_NO_PERIODIC_UPDATE" = "1"
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         name: Then outputs.status value must be 0 as the project itself makes use of pre-commit validation
         with:

--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,26 @@ runs:
       run: |
         CONFIG_PATH="${{ inputs.config-path }}"
         EXTRA_ARGS="${{ inputs.extra-args }}"
-        echo "CONFIG_PATH=$CONFIG_PATH" >> "$GITHUB_ENV"
-        echo "EXTRA_ARGS=$EXTRA_ARGS"   >> "$GITHUB_ENV"
+        {
+          echo "CONFIG_PATH=$CONFIG_PATH"
+          echo "EXTRA_ARGS=$EXTRA_ARGS"
+          echo "VIRTUALENV_PIP=embed"
+          echo "VIRTUALENV_SETUPTOOLS=embed"
+          echo "VIRTUALENV_WHEEL=embed"
+          echo "VIRTUALENV_DOWNLOAD=false"
+        } >> "$GITHUB_ENV"
+        if [[ -z "${PIP_INDEX_URL:-}" && -f "${HOME}/.pip/pip.conf" ]]; then
+          index_url="$(python3 -c 'import configparser, pathlib; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(c["global"]["index-url"])')"
+          echo "::add-mask::${index_url}"
+          host="$(python3 -c 'import configparser, pathlib, urllib.parse; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(urllib.parse.urlparse(c["global"]["index-url"]).hostname or "")')"
+          {
+            echo "PIP_INDEX_URL=${index_url}"
+            echo "VIRTUALENV_INDEX_URL=${index_url}"
+            if [[ -n "${host}" ]]; then
+              echo "PIP_TRUSTED_HOST=${host}"
+            fi
+          } >> "$GITHUB_ENV"
+        fi
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Fetch origin

--- a/action.yml
+++ b/action.yml
@@ -32,23 +32,8 @@ runs:
         {
           echo "CONFIG_PATH=$CONFIG_PATH"
           echo "EXTRA_ARGS=$EXTRA_ARGS"
-          echo "VIRTUALENV_PIP=embed"
-          echo "VIRTUALENV_SETUPTOOLS=embed"
-          echo "VIRTUALENV_WHEEL=embed"
-          echo "VIRTUALENV_DOWNLOAD=false"
+          echo "VIRTUALENV_NO_PERIODIC_UPDATE=1"
         } >> "$GITHUB_ENV"
-        if [[ -z "${PIP_INDEX_URL:-}" && -f "${HOME}/.pip/pip.conf" ]]; then
-          index_url="$(python3 -c 'import configparser, pathlib; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(c["global"]["index-url"])')"
-          echo "::add-mask::${index_url}"
-          host="$(python3 -c 'import configparser, pathlib, urllib.parse; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(urllib.parse.urlparse(c["global"]["index-url"]).hostname or "")')"
-          {
-            echo "PIP_INDEX_URL=${index_url}"
-            echo "VIRTUALENV_INDEX_URL=${index_url}"
-            if [[ -n "${host}" ]]; then
-              echo "PIP_TRUSTED_HOST=${host}"
-            fi
-          } >> "$GITHUB_ENV"
-        fi
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Fetch origin


### PR DESCRIPTION
## Summary
- Disable virtualenv's background periodic checks for newer embedded seed packages.
- Keep package-index configuration with the caller instead of parsing pip configuration inside this action.
- Leave virtualenv's normal bundled seed selection unchanged.

## Test plan
- [x] Existing integration tests pass
- [x] Integration test confirms `VIRTUALENV_NO_PERIODIC_UPDATE=1` is exported
- [x] A Harden Runner consumer confirms the action no longer contacts PyPI for virtualenv seed metadata