### PR TITLE
BUILD-12282: Route pre-commit pip installs through Repox

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   it-tests-use-input-default-values:

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -117,6 +117,21 @@ jobs:
           actual: ${{ steps.test-data.outputs.logs }}
           comparison: notContains
 
+  it-tests-repox-runner:
+    name: "IT Test - pip and npm hook installs work on a sonar-* runner (Repox)"
+    runs-on: sonar-xs
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Given the gh-action is used with default values on a sonar-* runner
+        id: test-data
+        uses: ./
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then outputs.status value must be 0 as the project itself makes use of pre-commit validation
+        with:
+          expected: 0
+          actual: ${{ steps.test-data.outputs.status }}
+          comparison: exact
+
   it-tests:
     name: "All IT Tests have to pass"
     runs-on: github-ubuntu-latest-s
@@ -129,6 +144,7 @@ jobs:
       - it-tests-output-status-success
       - it-tests-output-logs-failure
       - it-tests-output-logs-success
+      - it-tests-repox-runner
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,10 @@
 on:
   pull_request:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   pre-commit:
     name: "pre-commit"

--- a/README.md
+++ b/README.md
@@ -4,20 +4,33 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SonarSource_gh-action_pre-commit&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SonarSource_gh-action_pre-commit)
 [![.github/workflows/it-test.yml](https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml/badge.svg)](https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml)
 
-Run [pre-commit](https://pre-commit.com/) hooks at CI level
+Run [pre-commit](https://pre-commit.com/) hooks at CI level.
+
+This action is for **SonarSource internal** repositories. It authenticates to
+Vault and routes pip/npm/Node runtime downloads through Repox so hooks can
+install on `sonar-*` runners where public registries are blocked.
+
+## Breaking change (major version)
+
+Routing installs through Repox is a **breaking change** and will be released
+as a **major version**. Existing 1.x pins keep the previous behavior until
+callers upgrade.
+
+After upgrading:
+
+- The calling job **must** grant `id-token: write` (Vault OIDC) and
+  `contents: read`.
+- Workflows without that permission, **fork PRs** (no org Vault OIDC), and
+  runners **without Repox/Vault** (typical `ubuntu-latest` outside Sonar CI)
+  will fail at credential fetch. That is expected.
 
 ## Usage
 
 ### enforce pre-commit only to files changed within a pull request
 
-Place a `.pre-commit-config.yaml` at the root of your project
+Place a `.pre-commit-config.yaml` at the root of your project.
 
 Create a new GitHub workflow:
-
-This action installs Python and `pre-commit` via pip. On `sonar-*` runners, public
-package registries are blocked, so callers must grant Vault OIDC.
-The action configures authenticated Repox for **pip** and **npm** before
-installing dependencies.
 
 ```yaml
 # .github/workflows/pre-commit.yml
@@ -27,12 +40,12 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
     steps:
-      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last tag
+      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last major tag
         with:
           extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}
@@ -44,7 +57,7 @@ jobs:
 
 ### enforce pre-commit to all files systematically
 
-Place a `.pre-commit-config.yaml` at the root of your project
+Place a `.pre-commit-config.yaml` at the root of your project.
 
 Create a new GitHub workflow:
 
@@ -57,12 +70,12 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
     steps:
-      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last tag
+      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last major tag
         with:
           extra-args: --all-files
 ```
@@ -77,19 +90,18 @@ jobs:
 
 ### Required job permissions
 
-| Permission        | Why                                                                 |
-|-------------------|---------------------------------------------------------------------|
-| `id-token: write` | Lets the action authenticate to Vault and configure Repox for pip/npm |
-| `contents: read`  | Checkout and hook installation                                      |
+| Permission        | Why                                                                    |
+|-------------------|------------------------------------------------------------------------|
+| `id-token: write` | Lets the action authenticate to Vault and configure Repox for pip/npm  |
+| `contents: read`  | Checkout and hook installation                                         |
 
 ### Package registries used by common hooks
 
-Across SonarSource repos, pre-commit hooks most often install from:
-
 | Registry | Used by | Covered by this action |
 |----------|---------|------------------------|
-| PyPI (`pypi.org`) | `pre-commit-hooks`, `yamllint`, `check-jsonschema`, `sonar-secrets` | Yes (`PIP_INDEX_URL`, `VIRTUALENV_INDEX_URL`) |
-| npm (`registry.npmjs.org`) | `markdownlint-cli`, `renovatebot/pre-commit-hooks`, `mirrors-eslint` | Yes (`NPM_CONFIG_REGISTRY`, `~/.npmrc`) |
+| PyPI (`pypi.org`) | `pre-commit-hooks`, `yamllint`, `check-jsonschema`, `sonar-secrets` | Yes (`~/.pip/pip.conf`) |
+| npm (`registry.npmjs.org`) | `markdownlint-cli`, `renovatebot/pre-commit-hooks`, `mirrors-eslint` | Yes (`NPM_CONFIG_REGISTRY`, global npmrc) |
+| Node runtime (`nodejs.org/dist`) | `language: node` hooks via nodeenv | Yes (`~/.nodeenvrc` + `NODEJS_ORG_MIRROR` → Repox `nodejs-dist`) |
 | Go module proxy | `actionlint`, `terraform-docs` (golang hooks) | No — uses `proxy.golang.org` |
 | RubyGems | `markdownlint/markdownlint` (legacy) | No |
 | Maven / Gradle | Not used by pre-commit hook runtimes in SonarSource | N/A |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Place a `.pre-commit-config.yaml` at the root of your project
 
 Create a new GitHub workflow:
 
+This action installs Python and `pre-commit` via pip. On `sonar-*` runners, public
+package registries are blocked, so callers must grant Vault OIDC.
+The action configures authenticated Repox for **pip** and **npm** before
+installing dependencies.
+
 ```yaml
 # .github/workflows/pre-commit.yml
 on:
@@ -23,6 +28,9 @@ jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last tag
         with:
@@ -50,6 +58,9 @@ jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last tag
         with:
@@ -63,6 +74,27 @@ jobs:
 | `config-path`   | Used to specify a custom path to a given `.pre-commit-config.yaml` | `.pre-commit-config.yaml` |
 | `extra-args`    | Used to pass extra pre-commit args to the pre-commit run command   | -                         |
 | `ignore-failure` | Used to not fail the gh-action in case of pre-commit check failure | `false`                    |
+
+### Required job permissions
+
+| Permission        | Why                                                                 |
+|-------------------|---------------------------------------------------------------------|
+| `id-token: write` | Lets the action authenticate to Vault and configure Repox for pip/npm |
+| `contents: read`  | Checkout and hook installation                                      |
+
+### Package registries used by common hooks
+
+Across SonarSource repos, pre-commit hooks most often install from:
+
+| Registry | Used by | Covered by this action |
+|----------|---------|------------------------|
+| PyPI (`pypi.org`) | `pre-commit-hooks`, `yamllint`, `check-jsonschema`, `sonar-secrets` | Yes (`PIP_INDEX_URL`, `VIRTUALENV_INDEX_URL`) |
+| npm (`registry.npmjs.org`) | `markdownlint-cli`, `renovatebot/pre-commit-hooks`, `mirrors-eslint` | Yes (`NPM_CONFIG_REGISTRY`, `~/.npmrc`) |
+| Go module proxy | `actionlint`, `terraform-docs` (golang hooks) | No — uses `proxy.golang.org` |
+| RubyGems | `markdownlint/markdownlint` (legacy) | No |
+| Maven / Gradle | Not used by pre-commit hook runtimes in SonarSource | N/A |
+
+`language: script` / `language: system` hooks (e.g. `shellcheck`, `terraform-fmt`) do not download packages.
 
 ## Versioning
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,24 @@ runs:
       run: git fetch origin # avoid unknown revision or path not in the working tree when
       # using --from-ref --to-ref feature of pre-commit
       shell: bash
+    - name: Set Artifactory reader role
+      shell: bash
+      env:
+        ARTIFACTORY_READER_ROLE: ${{ github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader' }}
+      run: echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
+    - name: Fetch Repox credentials
+      uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      id: repox-secrets
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
+    - name: Configure Repox for pip and npm
+      shell: bash
+      env:
+        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.repox-secrets.outputs.vault).ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.repox-secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+      run: bash "${{ github.action_path }}/scripts/configure-repox.sh"
     - id: setup_python
       name: Setup python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/action.yml
+++ b/action.yml
@@ -37,18 +37,13 @@ runs:
       run: git fetch origin # avoid unknown revision or path not in the working tree when
       # using --from-ref --to-ref feature of pre-commit
       shell: bash
-    - name: Set Artifactory reader role
-      shell: bash
-      env:
-        ARTIFACTORY_READER_ROLE: ${{ github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader' }}
-      run: echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
     - name: Fetch Repox credentials
       uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
       id: repox-secrets
       with:
         secrets: |
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader' }} username | ARTIFACTORY_USERNAME;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader' }} access_token | ARTIFACTORY_ACCESS_TOKEN;
     - name: Configure Repox for pip and npm
       shell: bash
       env:

--- a/scripts/configure-repox.sh
+++ b/scripts/configure-repox.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Configure pip and npm to use authenticated Repox without config-pip/get-build-number.
+#
+# Required environment variables:
+# - ARTIFACTORY_USERNAME
+# - ARTIFACTORY_ACCESS_TOKEN
+#
+# Optional:
+# - REPOX_URL (default: https://repox.jfrog.io)
+
+set -euo pipefail
+
+: "${ARTIFACTORY_USERNAME:?}"
+: "${ARTIFACTORY_ACCESS_TOKEN:?}"
+
+REPOX_URL="${REPOX_URL:-https://repox.jfrog.io}"
+ARTIFACTORY_URL="${REPOX_URL%/}/artifactory"
+repox_host="${ARTIFACTORY_URL#https://}"
+repox_host="${repox_host#http://}"
+
+pip_index_url="https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${repox_host}/api/pypi/sonarsource-pypi/simple"
+npm_registry="${ARTIFACTORY_URL}/api/npm/npm"
+
+echo "::add-mask::${pip_index_url}"
+echo "::add-mask::${ARTIFACTORY_ACCESS_TOKEN}"
+
+mkdir -p "${HOME}/.pip"
+cat > "${HOME}/.pip/pip.conf" <<EOF
+[global]
+index-url = ${pip_index_url}
+EOF
+
+mkdir -p "${HOME}/.npm"
+cat > "${HOME}/.npmrc" <<EOF
+registry=${npm_registry}
+//${repox_host}/api/npm/:_authToken=${ARTIFACTORY_ACCESS_TOKEN}
+EOF
+
+{
+  echo "PIP_INDEX_URL=${pip_index_url}"
+  echo "VIRTUALENV_INDEX_URL=${pip_index_url}"
+  echo "VIRTUALENV_PIP=embed"
+  echo "VIRTUALENV_SETUPTOOLS=embed"
+  echo "VIRTUALENV_WHEEL=embed"
+  echo "VIRTUALENV_DOWNLOAD=false"
+  echo "PIP_TRUSTED_HOST=${repox_host%%/*}"
+  echo "NPM_CONFIG_REGISTRY=${npm_registry}"
+} >> "${GITHUB_ENV}"

--- a/scripts/configure-repox.sh
+++ b/scripts/configure-repox.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Configure pip and npm to use authenticated Repox without config-pip/get-build-number.
+# Configure pip, npm, and nodeenv to use authenticated Repox.
 #
 # Required environment variables:
 # - ARTIFACTORY_USERNAME
 # - ARTIFACTORY_ACCESS_TOKEN
+# - GITHUB_ENV
 #
 # Optional:
 # - REPOX_URL (default: https://repox.jfrog.io)
@@ -12,37 +13,71 @@ set -euo pipefail
 
 : "${ARTIFACTORY_USERNAME:?}"
 : "${ARTIFACTORY_ACCESS_TOKEN:?}"
+: "${GITHUB_ENV:?}"
 
 REPOX_URL="${REPOX_URL:-https://repox.jfrog.io}"
 ARTIFACTORY_URL="${REPOX_URL%/}/artifactory"
+repox_scheme="${ARTIFACTORY_URL%%://*}"
 repox_host="${ARTIFACTORY_URL#https://}"
 repox_host="${repox_host#http://}"
+repox_hostname="${repox_host%%/*}"
 
-pip_index_url="https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${repox_host}/api/pypi/sonarsource-pypi/simple"
+# ConfigParser interpolation treats % as a sequence; escape for pip.conf / nodeenvrc.
+ini_escape() {
+  printf '%s' "${1//%/%%}"
+}
+
+pip_index_url="${repox_scheme}://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${repox_host}/api/pypi/sonarsource-pypi/simple"
 npm_registry="${ARTIFACTORY_URL}/api/npm/npm"
+nodejs_mirror="${repox_scheme}://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${repox_host}/nodejs-dist"
 
-echo "::add-mask::${pip_index_url}"
+echo "::add-mask::${ARTIFACTORY_USERNAME}"
 echo "::add-mask::${ARTIFACTORY_ACCESS_TOKEN}"
+echo "::add-mask::${pip_index_url}"
+echo "::add-mask::${nodejs_mirror}"
+
+umask 077
 
 mkdir -p "${HOME}/.pip"
 cat > "${HOME}/.pip/pip.conf" <<EOF
 [global]
-index-url = ${pip_index_url}
+index-url = $(ini_escape "${pip_index_url}")
 EOF
+chmod 600 "${HOME}/.pip/pip.conf"
 
-mkdir -p "${HOME}/.npm"
-cat > "${HOME}/.npmrc" <<EOF
+# pre-commit unsets NPM_CONFIG_USERCONFIG for language: node hooks, so a
+# globalconfig file is required in addition to ~/.npmrc.
+npmrc="${RUNNER_TEMP:-${HOME}}/repox.npmrc"
+cat > "${npmrc}" <<EOF
 registry=${npm_registry}
+always-auth=true
 //${repox_host}/api/npm/:_authToken=${ARTIFACTORY_ACCESS_TOKEN}
 EOF
+chmod 600 "${npmrc}"
+cat >> "${HOME}/.npmrc" <<EOF
+registry=${npm_registry}
+always-auth=true
+//${repox_host}/api/npm/:_authToken=${ARTIFACTORY_ACCESS_TOKEN}
+EOF
+chmod 600 "${HOME}/.npmrc"
+
+# nodeenv reads ~/.nodeenvrc; it does not honor NODEJS_ORG_MIRROR.
+cat > "${HOME}/.nodeenvrc" <<EOF
+[nodeenv]
+mirror = $(ini_escape "${nodejs_mirror}")
+EOF
+chmod 600 "${HOME}/.nodeenvrc"
 
 {
-  echo "PIP_INDEX_URL=${pip_index_url}"
-  echo "VIRTUALENV_INDEX_URL=${pip_index_url}"
+  echo "PIP_CONFIG_FILE=${HOME}/.pip/pip.conf"
+  echo "PIP_TRUSTED_HOST=${repox_hostname}"
   echo "VIRTUALENV_PIP=embed"
   echo "VIRTUALENV_SETUPTOOLS=embed"
   echo "VIRTUALENV_WHEEL=embed"
   echo "VIRTUALENV_DOWNLOAD=false"
-  echo "PIP_TRUSTED_HOST=${repox_host%%/*}"
+  echo "NPM_CONFIG_GLOBALCONFIG=${npmrc}"
   echo "NPM_CONFIG_REGISTRY=${npm_registry}"
+  # node-gyp (and some npm native builds) still read these env vars.
+  echo "NODEJS_ORG_MIRROR=${nodejs_mirror}"
+  echo "NODE_MIRROR=${nodejs_mirror}"
 } >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary

- Configure authenticated Repox for **pip**, **npm**, and the **Node runtime** (nodeenv / `nodejs-dist`) before `setup-python` and hook installation, so pre-commit works on `sonar-*` runners where public registries are blocked
- Fetch Artifactory credentials via Vault OIDC (`vault-action-wrapper`) and write `chmod 600` config files (`pip.conf`, npmrc, `.nodeenvrc`) instead of going through `config-pip` / `get-build-number`
- Callers need `id-token: write` and `contents: read` (not `contents: write`)

## Breaking change (major version)

This will be released as a **major version**. Existing 1.x pins keep the previous behavior until callers upgrade.

After upgrading, the calling job must grant `id-token: write`. Workflows without that permission will fail at Vault authentication.

This action is for **SonarSource internal** usage. Fork PRs (no org Vault OIDC) and runners without Repox/Vault are expected to fail at credential fetch.

## Approach

Surveyed ~124 SonarSource repos: most pre-commit hooks install from **PyPI** and **npm**. `language: node` hooks also download the Node runtime from `nodejs.org` via nodeenv, so this routes that through Repox `nodejs-dist` (`~/.nodeenvrc`). Maven/Gradle are not used by pre-commit hook runtimes in the org.

## Test plan

- [x] IT test workflow passes on this PR (GitHub-hosted jobs)
- [x] New `it-tests-repox-runner` job passes on `sonar-xs` (pip + node hooks)
- [x] Pre-commit workflow passes on this PR