### PR TITLE
BUILD-12282: Stop routing nodeenv downloads through Repox

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,20 @@
 
 Run [pre-commit](https://pre-commit.com/) hooks at CI level.
 
-This action is for **SonarSource internal** repositories. It authenticates to
-Vault and routes pip/npm/Node runtime downloads through Repox so hooks can
-install on `sonar-*` runners where public registries are blocked.
+This action is for **SonarSource internal** repositories. It authenticates to Vault and routes pip/npm downloads through
+Repox so hooks can install on `sonar-*` runners where those public registries are blocked. Node runtimes keep using
+nodeenv's default `https://nodejs.org/download/release/` (not blocked).
 
 ## Breaking change (major version)
 
-Routing installs through Repox is a **breaking change** and will be released
-as a **major version**. Existing 1.x pins keep the previous behavior until
-callers upgrade.
+Routing installs through Repox is a **breaking change** and will be released as a **major version**. Existing 1.x pins
+keep the previous behavior until callers upgrade.
 
 After upgrading:
 
-- The calling job **must** grant `id-token: write` (Vault OIDC) and
-  `contents: read`.
-- Workflows without that permission, **fork PRs** (no org Vault OIDC), and
-  runners **without Repox/Vault** (typical `ubuntu-latest` outside Sonar CI)
-  will fail at credential fetch. That is expected.
+- The calling job **must** grant `id-token: write` (Vault OIDC) and `contents: read`.
+- Workflows without that permission, **fork PRs** (no org Vault OIDC), and runners **without Repox/Vault** (typical
+  `ubuntu-latest` outside Sonar CI) will fail at credential fetch. That is expected.
 
 ## Usage
 
@@ -82,29 +79,29 @@ jobs:
 
 ## Options
 
-| Option name     | Description                                                        | Default                   |
-|-----------------|--------------------------------------------------------------------|---------------------------|
-| `config-path`   | Used to specify a custom path to a given `.pre-commit-config.yaml` | `.pre-commit-config.yaml` |
-| `extra-args`    | Used to pass extra pre-commit args to the pre-commit run command   | -                         |
-| `ignore-failure` | Used to not fail the gh-action in case of pre-commit check failure | `false`                    |
+| Option name      | Description                                                        | Default                   |
+| ---------------- | ------------------------------------------------------------------ | ------------------------- |
+| `config-path`    | Used to specify a custom path to a given `.pre-commit-config.yaml` | `.pre-commit-config.yaml` |
+| `extra-args`     | Used to pass extra pre-commit args to the pre-commit run command   | -                         |
+| `ignore-failure` | Used to not fail the gh-action in case of pre-commit check failure | `false`                   |
 
 ### Required job permissions
 
-| Permission        | Why                                                                    |
-|-------------------|------------------------------------------------------------------------|
-| `id-token: write` | Lets the action authenticate to Vault and configure Repox for pip/npm  |
-| `contents: read`  | Checkout and hook installation                                         |
+| Permission        | Why                                                                   |
+| ----------------- | --------------------------------------------------------------------- |
+| `id-token: write` | Lets the action authenticate to Vault and configure Repox for pip/npm |
+| `contents: read`  | Checkout and hook installation                                        |
 
 ### Package registries used by common hooks
 
-| Registry | Used by | Covered by this action |
-|----------|---------|------------------------|
-| PyPI (`pypi.org`) | `pre-commit-hooks`, `yamllint`, `check-jsonschema`, `sonar-secrets` | Yes (`~/.pip/pip.conf`) |
-| npm (`registry.npmjs.org`) | `markdownlint-cli`, `renovatebot/pre-commit-hooks`, `mirrors-eslint` | Yes (`NPM_CONFIG_REGISTRY`, global npmrc) |
-| Node runtime (`nodejs.org/dist`) | `language: node` hooks via nodeenv | Yes (`~/.nodeenvrc` + `NODEJS_ORG_MIRROR` → Repox `nodejs-dist`) |
-| Go module proxy | `actionlint`, `terraform-docs` (golang hooks) | No — uses `proxy.golang.org` |
-| RubyGems | `markdownlint/markdownlint` (legacy) | No |
-| Maven / Gradle | Not used by pre-commit hook runtimes in SonarSource | N/A |
+| Registry                                     | Used by                                                              | Covered by this action                                          |
+| -------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
+| PyPI (`pypi.org`)                            | `pre-commit-hooks`, `yamllint`, `check-jsonschema`, `sonar-secrets`  | Yes (`~/.pip/pip.conf`)                                         |
+| npm (`registry.npmjs.org`)                   | `markdownlint-cli`, `renovatebot/pre-commit-hooks`, `mirrors-eslint` | Yes (`NPM_CONFIG_REGISTRY`, global npmrc)                       |
+| Node runtime (`nodejs.org/download/release`) | `language: node` hooks via nodeenv                                   | No — `nodejs.org` is reachable; nodeenv uses its default mirror |
+| Go module proxy                              | `actionlint`, `terraform-docs` (golang hooks)                        | No — uses `proxy.golang.org`                                    |
+| RubyGems                                     | `markdownlint/markdownlint` (legacy)                                 | No                                                              |
+| Maven / Gradle                               | Not used by pre-commit hook runtimes in SonarSource                  | N/A                                                             |
 
 `language: script` / `language: system` hooks (e.g. `shellcheck`, `terraform-fmt`) do not download packages.
 
@@ -112,9 +109,9 @@ jobs:
 
 This project is using [Semantic Versioning](https://semver.org/).
 
-The `master` branch shall not be referenced by end-users,
-please use tags instead and [Renovate](https://docs.renovatebot.com/) or
-[Dependabot](https://docs.github.com/en/code-security/dependabot) to stay up to date.
+The `master` branch shall not be referenced by end-users, please use tags instead and
+[Renovate](https://docs.renovatebot.com/) or [Dependabot](https://docs.github.com/en/code-security/dependabot) to stay
+up to date.
 
 ## Contribute
 

--- a/scripts/configure-repox.sh
+++ b/scripts/configure-repox.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Configure pip, npm, and nodeenv to use authenticated Repox.
+# Configure pip and npm to use authenticated Repox.
 #
 # Required environment variables:
 # - ARTIFACTORY_USERNAME
@@ -22,19 +22,17 @@ repox_host="${ARTIFACTORY_URL#https://}"
 repox_host="${repox_host#http://}"
 repox_hostname="${repox_host%%/*}"
 
-# ConfigParser interpolation treats % as a sequence; escape for pip.conf / nodeenvrc.
+# ConfigParser interpolation treats % as a sequence; escape for pip.conf.
 ini_escape() {
   printf '%s' "${1//%/%%}"
 }
 
 pip_index_url="${repox_scheme}://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${repox_host}/api/pypi/sonarsource-pypi/simple"
 npm_registry="${ARTIFACTORY_URL}/api/npm/npm"
-nodejs_mirror="${repox_scheme}://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${repox_host}/nodejs-dist"
 
 echo "::add-mask::${ARTIFACTORY_USERNAME}"
 echo "::add-mask::${ARTIFACTORY_ACCESS_TOKEN}"
 echo "::add-mask::${pip_index_url}"
-echo "::add-mask::${nodejs_mirror}"
 
 umask 077
 
@@ -61,13 +59,6 @@ always-auth=true
 EOF
 chmod 600 "${HOME}/.npmrc"
 
-# nodeenv reads ~/.nodeenvrc; it does not honor NODEJS_ORG_MIRROR.
-cat > "${HOME}/.nodeenvrc" <<EOF
-[nodeenv]
-mirror = $(ini_escape "${nodejs_mirror}")
-EOF
-chmod 600 "${HOME}/.nodeenvrc"
-
 {
   echo "PIP_CONFIG_FILE=${HOME}/.pip/pip.conf"
   echo "PIP_TRUSTED_HOST=${repox_hostname}"
@@ -77,7 +68,4 @@ chmod 600 "${HOME}/.nodeenvrc"
   echo "VIRTUALENV_DOWNLOAD=false"
   echo "NPM_CONFIG_GLOBALCONFIG=${npmrc}"
   echo "NPM_CONFIG_REGISTRY=${npm_registry}"
-  # node-gyp (and some npm native builds) still read these env vars.
-  echo "NODEJS_ORG_MIRROR=${nodejs_mirror}"
-  echo "NODE_MIRROR=${nodejs_mirror}"
 } >> "${GITHUB_ENV}"


### PR DESCRIPTION
BUILD-12282: Stop routing nodeenv downloads through Repox

## Summary
- Leave nodeenv on the public `https://nodejs.org/dist/` mirror; that host is reachable from `sonar-*` runners and does not need Repox.
- Keep pip and npm routed through authenticated Repox.
- This unblocks `language: node` hooks that set `language_version: lts` (e.g. renovate-config-validator). Embedding a Repox JWT in the nodeenv mirror URL made Python urllib treat the token as a port (`InvalidURL: nonnumeric port`).

## Test plan
- [x] Action IT job `it-tests-repox-runner` on `sonar-xs` (pip/npm + nodeenv from nodejs.org)
- [x] Dogfood on SonarSource/sonar-dummy#644 after `v2` points at this branch