### PR TITLE
BUILD-7053: Provide sensible defaults for PR and branch triggers

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,5 @@
+# Configuration for https://github.com/rhysd/actionlint run by pre-commit
+self-hosted-runner:
+  labels:
+    - sonar-xs
+    - ubuntu-latest

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -122,6 +122,7 @@ jobs:
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given the gh-action is used with default values on a sonar-* runner
         id: test-data
         uses: ./

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -7,13 +7,18 @@ permissions:
   id-token: write
   contents: read
 
+# sonar-xs does not ship shellcheck. Any job that executes this repo's
+# .pre-commit-config.yaml must run SonarSource/mise-action-wrapper@v1 first.
+# Fixture configs under .github/tests/resources/ do not use shellcheck.
+
 jobs:
 
   it-tests-use-input-default-values:
     name: "IT Test - default inputs values should work fine on this repo"
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given the gh-action is used with default values
         id: test-data
         uses: ./
@@ -24,9 +29,144 @@ jobs:
           actual: ${{ steps.test-data.outputs.status }}
           comparison: exact
 
+  it-tests-default-extra-args:
+    name: "IT Test - default extra-args is the PR diff on pull_request and --all-files on push"
+    runs-on: sonar-xs
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Given fail-check config and no extra-args
+        id: test-data
+        uses: ./
+        with:
+          config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
+          ignore-failure: 'true'
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then PR runs skip files outside the diff (status 0); branch runs scan all files (status 1)
+        with:
+          expected: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+          actual: ${{ steps.test-data.outputs.status }}
+          comparison: exact
+
+  it-tests-skip-checkout:
+    name: "IT Test - skips checkout when the workspace is already this repository"
+    runs-on: sonar-xs
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Given an uncommitted change that a fresh checkout would discard
+        run: echo "skip-checkout-marker" >> README.md
+      - name: When the action runs against this workspace
+        uses: ./
+        with:
+          extra-args: --help
+          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
+      - name: Read the working tree
+        id: marker
+        run: |
+          {
+            echo "readme<<EOF"
+            cat README.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then the uncommitted change is still present
+        with:
+          expected: skip-checkout-marker
+          actual: ${{ steps.marker.outputs.readme }}
+          comparison: contains
+
+  it-tests-does-checkout:
+    name: "IT Test - checks out when origin is not this repository"
+    runs-on: sonar-xs
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Given an uncommitted change and an origin that is a different repository
+        run: |
+          echo "must-checkout-marker" >> README.md
+          git remote set-url origin https://github.com/octocat/Hello-World.git
+      - name: When the action runs against this workspace
+        uses: ./
+        with:
+          extra-args: --help
+          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
+      - name: Read the working tree
+        id: marker
+        run: |
+          {
+            echo "readme<<EOF"
+            cat README.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then a fresh checkout discarded the uncommitted change
+        with:
+          expected: must-checkout-marker
+          actual: ${{ steps.marker.outputs.readme }}
+          comparison: notContains
+
+  it-tests-fetch-missing-refs:
+    name: "IT Test - fetches origin when from-ref is missing locally"
+    runs-on: sonar-xs
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+      - name: Given origin/base is not a local ref and a marker checkout would discard
+        id: before
+        env:
+          BASE: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+        run: |
+          echo "fetch-missing-refs-marker" >> README.md
+          git update-ref -d "refs/remotes/origin/${BASE}" || true
+          if git rev-parse --verify --quiet "origin/${BASE}^{commit}" >/dev/null; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then the from-ref is missing before the action
+        with:
+          expected: "false"
+          actual: ${{ steps.before.outputs.present }}
+          comparison: exact
+      - name: When extra-args require that from-ref
+        uses: ./
+        with:
+          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref || github.event.repository.default_branch }} --to-ref=${{ github.sha }}
+          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
+          ignore-failure: 'true'
+      - name: Read whether origin/base exists and the marker remains
+        id: after
+        env:
+          BASE: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+        run: |
+          if git rev-parse --verify --quiet "origin/${BASE}^{commit}" >/dev/null; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo "readme<<EOF"
+            cat README.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then origin was fetched so the from-ref resolves
+        with:
+          expected: "true"
+          actual: ${{ steps.after.outputs.present }}
+          comparison: exact
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then checkout was skipped (so the fetch script restored the ref, not checkout)
+        with:
+          expected: fetch-missing-refs-marker
+          actual: ${{ steps.after.outputs.readme }}
+          comparison: contains
+
   it-tests-use-input-extra-args:
     name: "IT Test - custom extra-args should be honored"
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given the gh-action is used with extra-args=--help
@@ -34,6 +174,7 @@ jobs:
         uses: ./
         with:
           extra-args: --help
+          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         name: Then outputs.logs should contain some printed documentation
         with:
@@ -41,9 +182,9 @@ jobs:
           actual: ${{ steps.test-data.outputs.logs }}
           comparison: contains
 
-  it-tests-output-status-failure:
-    name: "IT Test - output status should be 1 given pre-commit detected some issue"
-    runs-on: github-ubuntu-latest-s
+  it-tests-output-on-failure:
+    name: "IT Test - outputs surface a pre-commit failure without failing the job"
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config not correctly respected
@@ -54,53 +195,21 @@ jobs:
           config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
           ignore-failure: 'true'
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.status value must be 1 as there are some errors
+        name: Then outputs.status value must be 1
         with:
           expected: 1
           actual: ${{ steps.test-data.outputs.status }}
           comparison: exact
-
-  it-tests-output-status-success:
-    name: "IT Test - output status should be 0 given pre-commit detected no issue"
-    runs-on: github-ubuntu-latest-s
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Given a pre-commit-config correctly respected
-        id: test-data
-        uses: ./
-        with:
-          extra-args: '--all-files'
-          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
-          ignore-failure: 'true'
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.status value must be 0 as there are no errors
-        with:
-          expected: 0
-          actual: ${{ steps.test-data.outputs.status }}
-          comparison: exact
-
-  it-tests-output-logs-failure:
-    name: "IT Test - output logs should contain failures given pre-commit detected some issue"
-    runs-on: github-ubuntu-latest-s
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Given a pre-commit-config not correctly respected
-        id: test-data
-        uses: ./
-        with:
-          extra-args: '--all-files'
-          config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
-          ignore-failure: 'true'
-      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then it has to contain the failure message in the outputs.logs
+        name: Then outputs.logs contain the failure
         with:
           expected: "Failed"
           actual: ${{ steps.test-data.outputs.logs }}
           comparison: contains
 
-  it-tests-output-logs-success:
-    name: "IT Test - output logs should contain no failure given pre-commit detected no issue"
-    runs-on: github-ubuntu-latest-s
+  it-tests-output-on-success:
+    name: "IT Test - outputs surface a pre-commit success"
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config correctly respected
@@ -111,41 +220,32 @@ jobs:
           config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
           ignore-failure: 'true'
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then it should not contain any 'Failed' in the outputs.logs
+        name: Then outputs.status value must be 0
+        with:
+          expected: 0
+          actual: ${{ steps.test-data.outputs.status }}
+          comparison: exact
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then outputs.logs do not contain a failure
         with:
           expected: "Failed"
           actual: ${{ steps.test-data.outputs.logs }}
           comparison: notContains
 
-  it-tests-repox-runner:
-    name: "IT Test - pip and npm hook installs work on a sonar-* runner (Repox)"
-    runs-on: sonar-xs
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: SonarSource/mise-action-wrapper@v1
-      - name: Given the gh-action is used with default values on a sonar-* runner
-        id: test-data
-        uses: ./
-      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.status value must be 0 as the project itself makes use of pre-commit validation
-        with:
-          expected: 0
-          actual: ${{ steps.test-data.outputs.status }}
-          comparison: exact
-
   it-tests:
     name: "All IT Tests have to pass"
-    runs-on: github-ubuntu-latest-s
+    runs-on: ubuntu-latest
     if: always()
     needs:
       # Add your tests here so that they prevent the merge of broken changes
       - it-tests-use-input-default-values
+      - it-tests-default-extra-args
+      - it-tests-skip-checkout
+      - it-tests-does-checkout
+      - it-tests-fetch-missing-refs
       - it-tests-use-input-extra-args
-      - it-tests-output-status-failure
-      - it-tests-output-status-success
-      - it-tests-output-logs-failure
-      - it-tests-output-logs-success
-      - it-tests-repox-runner
+      - it-tests-output-on-failure
+      - it-tests-output-on-success
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -20,14 +20,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: SonarSource/mise-action-wrapper@v1
       - name: Given the gh-action is used with default values
-        id: test-data
         uses: ./
-      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.status value must be 0 as the project itself makes use of pre-commit validation
-        with:
-          expected: 0
-          actual: ${{ steps.test-data.outputs.status }}
-          comparison: exact
 
   it-tests-default-extra-args:
     name: "IT Test - default extra-args is the PR diff on pull_request and --all-files on push"
@@ -38,15 +31,15 @@ jobs:
           fetch-depth: 0
       - name: Given fail-check config and no extra-args
         id: test-data
+        continue-on-error: true
         uses: ./
         with:
           config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
-          ignore-failure: 'true'
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then PR runs skip files outside the diff (status 0); branch runs scan all files (status 1)
+        name: Then PR runs skip files outside the diff (success); branch runs scan all files (failure)
         with:
-          expected: ${{ github.event_name == 'pull_request' && '0' || '1' }}
-          actual: ${{ steps.test-data.outputs.status }}
+          expected: ${{ github.event_name == 'pull_request' && 'success' || 'failure' }}
+          actual: ${{ steps.test-data.outcome }}
           comparison: exact
 
   it-tests-skip-checkout:
@@ -135,7 +128,6 @@ jobs:
         with:
           extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref || github.event.repository.default_branch }} --to-ref=${{ github.sha }}
           config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
-          ignore-failure: 'true'
       - name: Read whether origin/base exists and the marker remains
         id: after
         env:
@@ -169,68 +161,62 @@ jobs:
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Given the gh-action is used with extra-args=--help
+      - name: Given fail-check config and extra-args=--all-files
         id: test-data
-        uses: ./
-        with:
-          extra-args: --help
-          config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
-      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.logs should contain some printed documentation
-        with:
-          expected: "usage: pre-commit run"
-          actual: ${{ steps.test-data.outputs.logs }}
-          comparison: contains
-
-  it-tests-output-on-failure:
-    name: "IT Test - outputs surface a pre-commit failure without failing the job"
-    runs-on: sonar-xs
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Given a pre-commit-config not correctly respected
-        id: test-data
+        continue-on-error: true
         uses: ./
         with:
           extra-args: '--all-files'
           config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
-          ignore-failure: 'true'
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.status value must be 1
+        name: Then the action fails (on a PR the default diff would skip the fixture and succeed)
         with:
-          expected: 1
-          actual: ${{ steps.test-data.outputs.status }}
+          expected: failure
+          actual: ${{ steps.test-data.outcome }}
           comparison: exact
-      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.logs contain the failure
+      - name: And extra-args restricted to a file the failing hook ignores
+        id: scoped
+        continue-on-error: true
+        uses: ./
         with:
-          expected: "Failed"
-          actual: ${{ steps.test-data.outputs.logs }}
-          comparison: contains
+          extra-args: '--files .github/tests/resources/success-check/valid.json'
+          config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then the action succeeds (on push the default --all-files would fail)
+        with:
+          expected: success
+          actual: ${{ steps.scoped.outcome }}
+          comparison: exact
 
-  it-tests-output-on-success:
-    name: "IT Test - outputs surface a pre-commit success"
+  it-tests-fails-job-on-failure:
+    name: "IT Test - failing pre-commit fails the action step"
+    runs-on: sonar-xs
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Given a failing config
+        id: test-data
+        continue-on-error: true
+        uses: ./
+        with:
+          extra-args: '--all-files'
+          config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then the action step fails while the job continues
+        with:
+          expected: failure
+          actual: ${{ steps.test-data.outcome }}
+          comparison: exact
+
+  it-tests-succeeds-on-success:
+    name: "IT Test - a passing pre-commit config succeeds"
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Given a pre-commit-config correctly respected
-        id: test-data
         uses: ./
         with:
           extra-args: '--all-files'
           config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
-          ignore-failure: 'true'
-      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.status value must be 0
-        with:
-          expected: 0
-          actual: ${{ steps.test-data.outputs.status }}
-          comparison: exact
-      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then outputs.logs do not contain a failure
-        with:
-          expected: "Failed"
-          actual: ${{ steps.test-data.outputs.logs }}
-          comparison: notContains
 
   it-tests:
     name: "All IT Tests have to pass"
@@ -244,8 +230,8 @@ jobs:
       - it-tests-does-checkout
       - it-tests-fetch-missing-refs
       - it-tests-use-input-extra-args
-      - it-tests-output-on-failure
-      - it-tests-output-on-success
+      - it-tests-fails-job-on-failure
+      - it-tests-succeeds-on-success
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+  merge_group:
   push:
     branches: [master]
 
@@ -23,7 +24,7 @@ jobs:
         uses: ./
 
   it-tests-default-extra-args:
-    name: "IT Test - default extra-args is the PR diff on pull_request and --all-files on push"
+    name: "IT Test - default extra-args is the event diff on pull_request/merge_group and --all-files on push"
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -36,9 +37,9 @@ jobs:
         with:
           config-path: '.github/tests/resources/fail-check/.pre-commit-config.yaml'
       - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
-        name: Then PR runs skip files outside the diff (success); branch runs scan all files (failure)
+        name: Then PR and merge_group runs skip files outside the diff (success); branch runs scan all files (failure)
         with:
-          expected: ${{ github.event_name == 'pull_request' && 'success' || 'failure' }}
+          expected: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'success' || 'failure' }}
           actual: ${{ steps.test-data.outcome }}
           comparison: exact
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,8 @@
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   id-token: write
@@ -8,11 +11,9 @@ permissions:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: ./
-        with:
-          extra-args: >
-            --from-ref=origin/${{ github.event.pull_request.base.ref }}
-            --to-ref=${{ github.event.pull_request.head.sha }}
+      - uses: SonarSource/mise-action-wrapper@v1
+      - name: Run pre-commit
+        uses: ./

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,29 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9  # frozen: v4.4.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 78690b6ce14891a2ae695190a74e966217eec3c8  # frozen: 0.33.0
+    rev: c4654a7e007c9619a5eb63c39a456572a0fa1851  # frozen: 0.38.0
     hooks:
       - id: check-github-actions
         files: .*/action.ya?ml
       - id: check-github-workflows
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: 5341f388c2a962d3bc66e075f00b80ab45b15f24 # v0.1.20
+    rev: 40f924cd642f5dc98d12bd97b07f3752223553da  # frozen: v0.1.30
     hooks:
       - id: shellcheck
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: c9ea83146232fb263effdfe6f222d87f5395b27a # v0.39.0
+    rev: 5b5dddc4fb0f83c3ea1fc5616fa63e115dce83e0  # frozen: v0.49.1
     hooks:
       - id: markdownlint
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 32ee411cf36142e6082f10870ae62172ce9af133  # frozen: 35.32.0
+    rev: 15e479eeb5c807ea833e0ad90ed360c5f322cf4b  # frozen: 44.57.3
     hooks:
       - id: renovate-config-validator
+  - repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
+    hooks:
+      - id: actionlint

--- a/DEV.md
+++ b/DEV.md
@@ -25,8 +25,8 @@ the job called `it-tests` declares a list of needs:
     ...
     needs:
        ...
-      - it-tests-output-on-failure
-      - it-tests-output-on-success
+      - it-tests-fails-job-on-failure
+      - it-tests-succeeds-on-success
       - < your new test > <-------------- Add your tests here
 ```
 

--- a/DEV.md
+++ b/DEV.md
@@ -25,7 +25,11 @@ the job called `it-tests` declares a list of needs:
     ...
     needs:
        ...
-      - it-tests-output-logs-failure
-      - it-tests-output-logs-success
+      - it-tests-output-on-failure
+      - it-tests-output-on-success
       - < your new test > <-------------- Add your tests here
 ```
+
+Jobs that execute this repository's `.pre-commit-config.yaml` on `sonar-xs` must
+install shellcheck first (`uses: SonarSource/mise-action-wrapper@v1`). Fixture
+configs under `.github/tests/resources/` do not need it.

--- a/README.md
+++ b/README.md
@@ -10,29 +10,36 @@ This action is for **SonarSource internal** repositories. It authenticates to Va
 Repox so hooks can install on `sonar-*` runners where those public registries are blocked. Node runtimes keep using
 nodeenv's default `https://nodejs.org/download/release/` (not blocked).
 
-## Breaking change (major version)
+## Breaking change (v2)
 
-Routing installs through Repox is a **breaking change** and will be released as a **major version**. Existing 1.x pins
-keep the previous behavior until callers upgrade.
+v2 is a **major version**. Existing 1.x pins keep the previous behavior until callers upgrade.
 
-After upgrading:
+- **`id-token: write` is required** (Vault OIDC for Repox). `contents: read` was already required. Workflows without
+  `id-token: write` and **fork PRs** (no org Vault OIDC) will fail at credential fetch. That is expected.
+- **Branch triggers are supported.** On `push` / `workflow_dispatch` (and other non-PR events) the action
+  defaults to `--all-files`.
+- **PRs default to diff validation.** You no longer need `extra-args` with `--from-ref` / `--to-ref`;
+  that is the default on `pull_request`.
 
-- The calling job **must** grant `id-token: write` (Vault OIDC) and `contents: read`.
-- Workflows without that permission, **fork PRs** (no org Vault OIDC), and runners **without Repox/Vault** (typical
-  `ubuntu-latest` outside Sonar CI) will fail at credential fetch. That is expected.
+If the job has already cloned this repository (`origin` owner/repo matches), the action **skips**
+`actions/checkout`. If `--from-ref` / `--to-ref` are missing locally, it runs `git fetch origin`.
+That fetch uses credentials persisted by the caller's `actions/checkout` (`persist-credentials: true`,
+the default). Do not set `persist-credentials: false` unless the needed refs are already local
+(`fetch-depth: 0`).
 
 ## Usage
 
-### enforce pre-commit only to files changed within a pull request
-
 Place a `.pre-commit-config.yaml` at the root of your project.
 
-Create a new GitHub workflow:
+On pull requests the action checks files changed in the PR. On branch events it checks all files.
 
 ```yaml
 # .github/workflows/pre-commit.yml
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   pre-commit:
@@ -42,48 +49,24 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with the last major tag
+      - uses: actions/checkout@v7
         with:
-          extra-args: >
-            --from-ref=origin/${{ github.event.pull_request.base.ref }}
-            --to-ref=${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: SonarSource/gh-action_pre-commit@v2
 ```
 
-> Notice: the extra-args parameter defined upper ensure that only files changed within the PR are checked by pre-commit.
-> If you rather like to ensure that **all files** are valid, have a look at the example below.
-
-### enforce pre-commit to all files systematically
-
-Place a `.pre-commit-config.yaml` at the root of your project.
-
-Create a new GitHub workflow:
-
-```yaml
-# .github/workflows/pre-commit.yml
-on:
-  branch:
-    - master
-
-jobs:
-  pre-commit:
-    name: "pre-commit"
-    runs-on: sonar-xs
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: SonarSource/gh-action_pre-commit@0.0.1 <--- replace with last major tag
-        with:
-          extra-args: --all-files
-```
+`fetch-depth: 0` makes `--from-ref` / `--to-ref` resolvable. If checkout is omitted, this action clones
+the repo itself. When checkout is skipped, this action still expects persisted credentials from
+`actions/checkout` so it can fetch missing refs. Pass `extra-args` only when you need different
+pre-commit flags.
 
 ## Options
 
-| Option name      | Description                                                        | Default                   |
-| ---------------- | ------------------------------------------------------------------ | ------------------------- |
-| `config-path`    | Used to specify a custom path to a given `.pre-commit-config.yaml` | `.pre-commit-config.yaml` |
-| `extra-args`     | Used to pass extra pre-commit args to the pre-commit run command   | -                         |
-| `ignore-failure` | Used to not fail the gh-action in case of pre-commit check failure | `false`                   |
+| Option name      | Description                                                               | Default                                         |
+| ---------------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
+| `config-path`    | Used to specify a custom path to a given `.pre-commit-config.yaml`        | `.pre-commit-config.yaml`                       |
+| `extra-args`     | Extra args for `pre-commit run`. PR: changed files; branch: `--all-files` | PR: `--from-ref`/`--to-ref`; else `--all-files` |
+| `ignore-failure` | Used to not fail the gh-action in case of pre-commit check failure        | `false`                                         |
 
 ### Required job permissions
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SonarSource GitHub Action for pre-commit
 
 ![GitHub Release](https://img.shields.io/github/v/release/SonarSource/gh-action_pre-commit)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SonarSource_gh-action_pre-commit&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SonarSource_gh-action_pre-commit)
-[![.github/workflows/it-test.yml](https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml/badge.svg)](https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml)
+![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SonarSource_gh-action_pre-commit&metric=alert_status)
+![.github/workflows/it-test.yml](https://github.com/SonarSource/gh-action_pre-commit/actions/workflows/it-test.yml/badge.svg)
 
 Run [pre-commit](https://pre-commit.com/) hooks at CI level.
 
@@ -14,15 +14,15 @@ nodeenv's default `https://nodejs.org/download/release/` (not blocked).
 
 v2 is a **major version**. Existing 1.x pins keep the previous behavior until callers upgrade.
 
-- **`id-token: write` is required** (Vault OIDC for Repox). `contents: read` was already required. Workflows without
-  `id-token: write` and **fork PRs** (no org Vault OIDC) will fail at credential fetch. That is expected.
-- **Branch triggers are supported.** On `push` / `workflow_dispatch` (and other non-PR events) the action
-  defaults to `--all-files`.
-- **PRs default to diff validation.** You no longer need `extra-args` with `--from-ref` / `--to-ref`;
-  that is the default on `pull_request`.
-- **`status` and `logs` outputs are removed.** Use `steps.<id>.outcome` on the action step.
-- **`ignore-failure` is removed.** Use `continue-on-error: true` on the action step if the job
-  must continue after hook failures.
+- `**id-token: write` is required** (Vault OIDC for Repox). `contents: read` was already required. Workflows without
+`id-token: write` and **fork PRs** (no org Vault OIDC) will fail at credential fetch. That is expected.
+- `**merge_group` is supported.** v2 defaults to incremental `--from-ref` / `--to-ref` on merge-queue
+events (`base_sha`…`head_sha`). Hook failures fail the job; do not ignore them on that trigger.
+- **PRs default to the same diff validation** on `pull_request`. You no longer need `extra-args`.
+- **Branch triggers are supported.** On `push` / `workflow_dispatch` (and other events) the action
+defaults to `--all-files`.
+- `**status` and `logs` outputs are removed.**
+- `ignore-failure` **input is removed.** Hook failures fail the action step.
 
 If the job has already cloned this repository (`origin` owner/repo matches), the action **skips**
 `actions/checkout`. If `--from-ref` / `--to-ref` are missing locally, it runs `git fetch origin`.
@@ -35,6 +35,8 @@ the default). Do not set `persist-credentials: false` unless the needed refs are
 Place a `.pre-commit-config.yaml` at the root of your project.
 
 On pull requests the action checks files changed in the PR. On branch events it checks all files.
+`merge_group` is also supported: the action defaults to incremental `--from-ref` / `--to-ref` on
+that trigger (`base_sha`…`head_sha`).
 
 ```yaml
 # .github/workflows/pre-commit.yml
@@ -44,9 +46,10 @@ on:
     branches:
       - master
 
+name: pre-commit
+
 jobs:
   pre-commit:
-    name: "pre-commit"
     runs-on: sonar-xs
     permissions:
       id-token: write
@@ -63,23 +66,12 @@ the repo itself. When checkout is skipped, this action still expects persisted c
 `actions/checkout` so it can fetch missing refs. Pass `extra-args` only when you need different
 pre-commit flags.
 
-To keep the job green on a specific trigger, make `continue-on-error` conditional. Here the job
-fails normally on `pull_request` / `push`, but hook failures are tolerated on `merge_group`:
-
-```yaml
-      - id: pre-commit
-        continue-on-error: ${{ github.event_name == 'merge_group' }}
-        uses: SonarSource/gh-action_pre-commit@v2
-      - if: steps.pre-commit.outcome == 'failure'
-        run: echo "pre-commit does not support running on merge_group. Ignoring errors"
-```
-
 ## Options
 
-| Option name   | Description                                                               | Default                                         |
-| ------------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
-| `config-path` | Used to specify a custom path to a given `.pre-commit-config.yaml`        | `.pre-commit-config.yaml`                       |
-| `extra-args`  | Extra args for `pre-commit run`. PR: changed files; branch: `--all-files` | PR: `--from-ref`/`--to-ref`; else `--all-files` |
+| Option name   | Description                                                               | Default                                                       |
+| ------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `config-path` | Used to specify a custom path to a given `.pre-commit-config.yaml`        | `.pre-commit-config.yaml`                                     |
+| `extra-args`  | Extra args for `pre-commit run`. Diff on PR / merge queue; else all files | PR/`merge_group`: `--from-ref`/`--to-ref`; else `--all-files` |
 
 ### Required job permissions
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ v2 is a **major version**. Existing 1.x pins keep the previous behavior until ca
   defaults to `--all-files`.
 - **PRs default to diff validation.** You no longer need `extra-args` with `--from-ref` / `--to-ref`;
   that is the default on `pull_request`.
+- **`status` and `logs` outputs are removed.** Use `steps.<id>.outcome` on the action step.
+- **`ignore-failure` is removed.** Use `continue-on-error: true` on the action step if the job
+  must continue after hook failures.
 
 If the job has already cloned this repository (`origin` owner/repo matches), the action **skips**
 `actions/checkout`. If `--from-ref` / `--to-ref` are missing locally, it runs `git fetch origin`.
@@ -60,13 +63,23 @@ the repo itself. When checkout is skipped, this action still expects persisted c
 `actions/checkout` so it can fetch missing refs. Pass `extra-args` only when you need different
 pre-commit flags.
 
+To keep the job green on a specific trigger, make `continue-on-error` conditional. Here the job
+fails normally on `pull_request` / `push`, but hook failures are tolerated on `merge_group`:
+
+```yaml
+      - id: pre-commit
+        continue-on-error: ${{ github.event_name == 'merge_group' }}
+        uses: SonarSource/gh-action_pre-commit@v2
+      - if: steps.pre-commit.outcome == 'failure'
+        run: echo "pre-commit does not support running on merge_group. Ignoring errors"
+```
+
 ## Options
 
-| Option name      | Description                                                               | Default                                         |
-| ---------------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
-| `config-path`    | Used to specify a custom path to a given `.pre-commit-config.yaml`        | `.pre-commit-config.yaml`                       |
-| `extra-args`     | Extra args for `pre-commit run`. PR: changed files; branch: `--all-files` | PR: `--from-ref`/`--to-ref`; else `--all-files` |
-| `ignore-failure` | Used to not fail the gh-action in case of pre-commit check failure        | `false`                                         |
+| Option name   | Description                                                               | Default                                         |
+| ------------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
+| `config-path` | Used to specify a custom path to a given `.pre-commit-config.yaml`        | `.pre-commit-config.yaml`                       |
+| `extra-args`  | Extra args for `pre-commit run`. PR: changed files; branch: `--all-files` | PR: `--from-ref`/`--to-ref`; else `--all-files` |
 
 ### Required job permissions
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   extra-args:
     description: extra arguments passed to pre-commit run command
     required: false
-    default: "${{ github.event_name == 'pull_request' && format('--from-ref=origin/{0} --to-ref={1}', github.event.pull_request.base.ref, github.event.pull_request.head.sha) || '--all-files' }}"
+    default: "${{ github.event_name == 'pull_request' && format('--from-ref=origin/{0} --to-ref={1}', github.event.pull_request.base.ref, github.event.pull_request.head.sha) || github.event_name == 'merge_group' && format('--from-ref={0} --to-ref={1}', github.event.merge_group.base_sha, github.event.merge_group.head_sha) || '--all-files' }}"
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -9,17 +9,6 @@ inputs:
     description: extra arguments passed to pre-commit run command
     required: false
     default: "${{ github.event_name == 'pull_request' && format('--from-ref=origin/{0} --to-ref={1}', github.event.pull_request.base.ref, github.event.pull_request.head.sha) || '--all-files' }}"
-  ignore-failure:
-    description: Optional, do not fail the gh-action in case of pre-commit check failure
-    required: false
-    default: 'false'
-outputs:
-  status:
-    description: Provide the exit code returned by pre-commit run command
-    value: ${{ steps.exec-pre-commit.outputs.status }}
-  logs:
-    description: Logs from the pre-commit run command
-    value: ${{ steps.exec-pre-commit.outputs.logs }}
 
 runs:
   using: composite
@@ -102,36 +91,11 @@ runs:
       with:
         key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(env.CONFIG_PATH) }}
         path: ~/.cache/pre-commit
-    - id: exec-pre-commit
-      name: Execute pre-commit
+    - name: Execute pre-commit
       env:
         GIT_ASKPASS: /bin/true   # allowlisted by pre-commit's no_git_env
         GIT_CONFIG_COUNT: '1'
         GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ github.token }}@github.com/.insteadof"
         GIT_CONFIG_VALUE_0: "https://github.com/"
-      run: |
-        set +e
-        OUTPUT=$(pre-commit run --config="$CONFIG_PATH" --show-diff-on-failure --color=always $EXTRA_ARGS)
-        STATUS=$?
-        echo "status=$(echo $STATUS)" >> "$GITHUB_OUTPUT"
-        # Securely expose log a random delimiter
-        DELIM="DELIM_$(openssl rand -hex 16)"
-        while echo "$OUTPUT" | grep -q "$DELIM"; do
-          DELIM="DELIM_$(openssl rand -hex 16)"
-        done
-        echo "logs<<$DELIM" >> "$GITHUB_OUTPUT"
-        echo "$OUTPUT" >> "$GITHUB_OUTPUT"
-        echo "$DELIM" >> "$GITHUB_OUTPUT"
-        exit 0
-      shell: bash
-    - name: Print execution
-      run: |
-        echo "${{ steps.exec-pre-commit.outputs.logs }}"
-        echo "Exit code: ${{ steps.exec-pre-commit.outputs.status }}"
-      shell: bash
-    - name: Check status and fail if necessary
-      if: ${{ inputs.ignore-failure == 'false' && steps.exec-pre-commit.outputs.status != 0 }}
-      run: |
-        echo "::error ::pre-commit execution detected some issues"
-        exit 1
+      run: pre-commit run --config="$CONFIG_PATH" --show-diff-on-failure --color=always $EXTRA_ARGS
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   extra-args:
     description: extra arguments passed to pre-commit run command
     required: false
-    default: ''
+    default: "${{ github.event_name == 'pull_request' && format('--from-ref=origin/{0} --to-ref={1}', github.event.pull_request.base.ref, github.event.pull_request.head.sha) || '--all-files' }}"
   ignore-failure:
     description: Optional, do not fail the gh-action in case of pre-commit check failure
     required: false
@@ -31,12 +31,18 @@ runs:
         EXTRA_ARGS="${{ inputs.extra-args }}"
         echo "CONFIG_PATH=$CONFIG_PATH" >> "$GITHUB_ENV"
         echo "EXTRA_ARGS=$EXTRA_ARGS"   >> "$GITHUB_ENV"
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: Fetch origin
-      run: git fetch origin # avoid unknown revision or path not in the working tree when
-      # using --from-ref --to-ref feature of pre-commit
+    - name: Detect existing clone
+      id: detect-clone
       shell: bash
+      env:
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: bash "${{ github.action_path }}/scripts/detect-existing-clone.sh"
+    - name: Checkout
+      if: steps.detect-clone.outputs.skip_checkout != 'true'
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Fetch origin if from-ref/to-ref are missing
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/ensure-from-to-refs.sh"
     - name: Fetch Repox credentials
       uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
       id: repox-secrets

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+shellcheck = "0.11.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
+pre-commit = "4.6.2"
+python = "3.14.5"
 shellcheck = "0.11.0"

--- a/scripts/detect-existing-clone.sh
+++ b/scripts/detect-existing-clone.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Detect whether GITHUB_WORKSPACE is already a clone of this GitHub repository.
+#
+# Required environment variables:
+# - GITHUB_OUTPUT
+# - GITHUB_REPOSITORY (owner/repo)
+#
+# Sets skip_checkout=true when the workspace is a git work tree whose `origin`
+# remote matches GITHUB_REPOSITORY (owner/repo only, case-insensitive).
+
+: "${GITHUB_OUTPUT:?}"
+: "${GITHUB_REPOSITORY:?}"
+
+owner_repo_from_remote_url() {
+  local url="$1"
+  url="${url#"${url%%[![:space:]]*}"}"
+  url="${url%"${url##*[![:space:]]}"}"
+  url="${url%/}"
+  url="${url%.git}"
+
+  local rest
+  if [[ "$url" == *"://"* ]]; then
+    rest="${url#*://}"
+    rest="${rest##*@}"
+    rest="${rest#*/}"
+  else
+    rest="${url#*:}"
+  fi
+  rest="${rest%%\?*}"
+  rest="${rest%%#*}"
+  rest="${rest%/}"
+
+  if [[ "$rest" != */* ]]; then
+    return 1
+  fi
+  local repo="${rest##*/}"
+  local owner_path="${rest%/*}"
+  local owner="${owner_path##*/}"
+  if [[ -z "$owner" || -z "$repo" ]]; then
+    return 1
+  fi
+  printf '%s/%s\n' "$owner" "$repo"
+}
+
+skip_checkout=false
+
+if command -v git >/dev/null 2>&1 \
+  && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [[ -n "$origin_url" ]]; then
+    origin_owner_repo="$(owner_repo_from_remote_url "$origin_url" || true)"
+    expected="$(printf '%s' "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
+    actual="$(printf '%s' "${origin_owner_repo}" | tr '[:upper:]' '[:lower:]')"
+    if [[ -n "$actual" && "$actual" == "$expected" ]]; then
+      skip_checkout=true
+    fi
+  fi
+fi
+
+echo "skip_checkout=${skip_checkout}" >> "${GITHUB_OUTPUT}"
+if [[ "${skip_checkout}" == "true" ]]; then
+  echo "Workspace is already a clone of ${GITHUB_REPOSITORY}; skipping checkout."
+else
+  echo "No matching clone of ${GITHUB_REPOSITORY}; will checkout."
+fi

--- a/scripts/ensure-from-to-refs.sh
+++ b/scripts/ensure-from-to-refs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# If extra-args --from-ref/--to-ref values are missing locally, run git fetch origin.
+
+set -euo pipefail
+
+case " ${EXTRA_ARGS:-} " in
+  *" --all-files "* | *" -a "* | *" --files "* | *" --files="*)
+    exit 0
+    ;;
+esac
+
+refs=()
+prev=""
+# shellcheck disable=SC2086 # extra-args is a word-split flag list, same as pre-commit run
+for arg in ${EXTRA_ARGS:-}; do
+  case "$prev" in
+    --from-ref | --to-ref | --source | --origin | -s | -o)
+      refs+=("$arg")
+      prev=""
+      continue
+      ;;
+    *)
+      ;;
+  esac
+  case "$arg" in
+    --from-ref=* | --to-ref=* | --source=* | --origin=*)
+      refs+=("${arg#*=}")
+      prev=""
+      ;;
+    --from-ref | --to-ref | --source | --origin | -s | -o)
+      prev="$arg"
+      ;;
+    *)
+      prev=""
+      ;;
+  esac
+done
+
+for ref in ${refs[@]+"${refs[@]}"}; do
+  if git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+    continue
+  fi
+  echo "Missing ref '${ref}'; running git fetch origin"
+  GIT_TERMINAL_PROMPT=0 git fetch origin
+  exit 0
+done


### PR DESCRIPTION
https://sonarsource.atlassian.net/browse/BUILD-7053

## Summary

- Default `extra-args` so callers need no per-trigger configuration:
  - `pull_request`: incremental `--from-ref=origin/<base.ref> --to-ref=<head.sha>`
  - `merge_group`: incremental `--from-ref=<base_sha> --to-ref=<head_sha>`
  - other events (`push`, `workflow_dispatch`, …): `--all-files`
- Skip `actions/checkout` when the workspace is already a clone of this repository (`origin` owner/repo match). Fetch `origin` when `--from-ref` / `--to-ref` are missing locally.
- Print pre-commit output directly from the execute step (no shell interpolation of logs) and let `pre-commit run`'s exit code fail the step, so GitHub opens the job on the step that contains the real hook output. No synthetic `::error::` annotation is emitted.
- Remove `ignore-failure` and the `status` / `logs` outputs. Hook failures fail the action step.
- Document `merge_group` as a supported v2 trigger. The default usage snippet stays `pull_request` + `push`.

## Test plan

- [x] IT workflow passes on this PR (skip-checkout, missing-ref fetch, PR / `merge_group` diff vs `--all-files` on branch)
- [ ] Confirm a failing consumer job opens on the pre-commit hook output, not a generic fail step
- [ ] `pre-commit` job on `master` populates the hook cache
- [ ] Consumer with `on: merge_group` and no `extra-args` runs incrementally (no `ignore-failure` / `continue-on-error` workaround)