### PR TITLE
BUILD-12495: Authenticate git clones of pre-commit hook repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
 | Permission        | Why                                                                   |
 | ----------------- | --------------------------------------------------------------------- |
 | `id-token: write` | Lets the action authenticate to Vault and configure Repox for pip/npm |
-| `contents: read`  | Checkout and hook installation                                        |
+| `contents: read`  | Checkout, fetching refs, and cloning hook repos from github.com       |
 
 ### Package registries used by common hooks
 

--- a/action.yml
+++ b/action.yml
@@ -72,9 +72,13 @@ runs:
           exit 1
         fi
       shell: bash
-    # Step-scoped insteadOf (not git config --global) so hook clones in
-    # ~/.cache/pre-commit use GITHUB_TOKEN without adding a second Authorization
-    # header on the workspace remote (checkout persist-credentials extraheader).
+    # Step-scoped insteadOf (not `git config --global`) so only these two steps
+    # rewrite github.com URLs, letting hook clones in ~/.cache/pre-commit use
+    # GITHUB_TOKEN while the rest of the job (incl. `git fetch origin` above)
+    # keeps using checkout's persist-credentials extraheader untouched.
+    # NOTE: within these steps the workspace remote is rewritten too, so a hook
+    # that performs a network git op on `origin` will send both the extraheader
+    # and URL basic credentials.
     - id: setup-pre-commit-hooks
       if: steps.restore-cache.outputs.cache-hit != 'true'
       name: Install pre-commit dependencies

--- a/action.yml
+++ b/action.yml
@@ -72,9 +72,17 @@ runs:
           exit 1
         fi
       shell: bash
+    # Step-scoped insteadOf (not git config --global) so hook clones in
+    # ~/.cache/pre-commit use GITHUB_TOKEN without adding a second Authorization
+    # header on the workspace remote (checkout persist-credentials extraheader).
     - id: setup-pre-commit-hooks
       if: steps.restore-cache.outputs.cache-hit != 'true'
       name: Install pre-commit dependencies
+      env:
+        GIT_TERMINAL_PROMPT: '0'
+        GIT_CONFIG_COUNT: '1'
+        GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ github.token }}@github.com/.insteadof"
+        GIT_CONFIG_VALUE_0: "https://github.com/"
       run: |
         pre-commit install-hooks --config="$CONFIG_PATH"
       shell: bash
@@ -86,6 +94,11 @@ runs:
         path: ~/.cache/pre-commit
     - id: exec-pre-commit
       name: Execute pre-commit
+      env:
+        GIT_TERMINAL_PROMPT: '0'
+        GIT_CONFIG_COUNT: '1'
+        GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ github.token }}@github.com/.insteadof"
+        GIT_CONFIG_VALUE_0: "https://github.com/"
       run: |
         set +e
         OUTPUT=$(pre-commit run --config="$CONFIG_PATH" --show-diff-on-failure --color=always $EXTRA_ARGS)

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
       if: steps.restore-cache.outputs.cache-hit != 'true'
       name: Install pre-commit dependencies
       env:
-        GIT_TERMINAL_PROMPT: '0'
+        GIT_ASKPASS: /bin/true   # allowlisted by pre-commit's no_git_env
         GIT_CONFIG_COUNT: '1'
         GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ github.token }}@github.com/.insteadof"
         GIT_CONFIG_VALUE_0: "https://github.com/"
@@ -95,7 +95,7 @@ runs:
     - id: exec-pre-commit
       name: Execute pre-commit
       env:
-        GIT_TERMINAL_PROMPT: '0'
+        GIT_ASKPASS: /bin/true   # allowlisted by pre-commit's no_git_env
         GIT_CONFIG_COUNT: '1'
         GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ github.token }}@github.com/.insteadof"
         GIT_CONFIG_VALUE_0: "https://github.com/"


### PR DESCRIPTION
BUILD-12495

## Summary
- `pre-commit install-hooks` clones hook repos into `~/.cache/pre-commit`, which is outside `actions/checkout` persist-credentials (`includeIf.gitdir` on the workspace only). Unauthenticated `git fetch` of those repos fails intermittently on shared `sonar-*` IPs (`could not read Username for 'https://github.com'`).
- Rewrite `https://github.com/` to `https://x-access-token:${{ github.token }}@github.com/` via step-scoped `GIT_CONFIG_*` on **Install pre-commit dependencies** and **Execute pre-commit**. Not `--global`, so the workspace remote does not get a second Authorization header on top of checkout's extraheader.

## Test plan
- [ ] Action ITs pass (`it-test.yml`), including hook install on a cache miss
- [ ] Dogfood on `sonar-dummy-maven-enterprise` with `@<this-sha>` (or the PR ref) and confirm install-hooks clones hooks without the username error
- [ ] Workspace `--from-ref` / `git fetch origin` still works (no 400 from duplicate auth)