### PR TITLE
BUILD-12512: Refactor pre-commit tool install and S3 caching

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -8,9 +8,11 @@ permissions:
   id-token: write
   contents: read
 
-# sonar-xs does not ship shellcheck. Any job that executes this repo's
-# .pre-commit-config.yaml must run SonarSource/mise-action-wrapper@v1 first.
-# Fixture configs under .github/tests/resources/ do not use shellcheck.
+# sonar-xs does not ship shellcheck. Jobs that need this repo's hooks or a
+# pre-installed CLI run SonarSource/mise-action-wrapper@v1 after checkout
+# (mise.toml also provides python so setup-python is skipped).
+# it-tests-installs-pre-commit omits the wrapper so the action installs
+# pre-commit itself (fixture configs do not use shellcheck).
 
 jobs:
 
@@ -30,6 +32,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given fail-check config and no extra-args
         id: test-data
         continue-on-error: true
@@ -48,6 +51,7 @@ jobs:
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given an uncommitted change that a fresh checkout would discard
         run: echo "skip-checkout-marker" >> README.md
       - name: When the action runs against this workspace
@@ -75,6 +79,7 @@ jobs:
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given an uncommitted change and an origin that is a different repository
         run: |
           echo "must-checkout-marker" >> README.md
@@ -106,6 +111,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given origin/base is not a local ref and a marker checkout would discard
         id: before
         env:
@@ -162,6 +168,7 @@ jobs:
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given fail-check config and extra-args=--all-files
         id: test-data
         continue-on-error: true
@@ -194,6 +201,7 @@ jobs:
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: SonarSource/mise-action-wrapper@v1
       - name: Given a failing config
         id: test-data
         continue-on-error: true
@@ -208,16 +216,33 @@ jobs:
           actual: ${{ steps.test-data.outcome }}
           comparison: exact
 
-  it-tests-succeeds-on-success:
-    name: "IT Test - a passing pre-commit config succeeds"
+  it-tests-installs-pre-commit:
+    name: "IT Test - installs pre-commit when it is not pre-installed"
     runs-on: sonar-xs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Given a pre-commit-config correctly respected
+      - name: Given no pre-commit on PATH and a passing fixture config
         uses: ./
         with:
           extra-args: '--all-files'
           config-path: '.github/tests/resources/success-check/.pre-commit-config.yaml'
+      - name: Read the pre-commit the action left on PATH
+        id: installed
+        run: |
+          echo "pre_commit=$(command -v pre-commit)" >> "$GITHUB_OUTPUT"
+          echo "version=$(pre-commit --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then pre-commit is the action venv binary
+        with:
+          expected: ${{ runner.temp }}/gh-action-pre-commit-venv/bin/pre-commit
+          actual: ${{ steps.installed.outputs.pre_commit }}
+          comparison: exact
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
+        name: Then the installed version is 4.6.2
+        with:
+          expected: "4.6.2"
+          actual: ${{ steps.installed.outputs.version }}
+          comparison: exact
 
   it-tests:
     name: "All IT Tests have to pass"
@@ -232,7 +257,7 @@ jobs:
       - it-tests-fetch-missing-refs
       - it-tests-use-input-extra-args
       - it-tests-fails-job-on-failure
-      - it-tests-succeeds-on-success
+      - it-tests-installs-pre-commit
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/DEV.md
+++ b/DEV.md
@@ -26,10 +26,13 @@ the job called `it-tests` declares a list of needs:
     needs:
        ...
       - it-tests-fails-job-on-failure
-      - it-tests-succeeds-on-success
+      - it-tests-installs-pre-commit
       - < your new test > <-------------- Add your tests here
 ```
 
-Jobs that execute this repository's `.pre-commit-config.yaml` on `sonar-xs` must
-install shellcheck first (`uses: SonarSource/mise-action-wrapper@v1`). Fixture
-configs under `.github/tests/resources/` do not need it.
+Most IT jobs run `SonarSource/mise-action-wrapper@v1` after checkout. That
+pre-installs this repository's `mise.toml` tools (`pre-commit`, `python`,
+`shellcheck`) so the composite skips `setup-python` and its private CLI venv,
+and shellcheck is available for this repo's hooks.
+`it-tests-installs-pre-commit` omits the wrapper and asserts the action
+installs `pre-commit` into its private venv.

--- a/README.md
+++ b/README.md
@@ -16,27 +16,32 @@ v2 is a **major version**. Existing 1.x pins keep the previous behavior until ca
 
 - `**id-token: write` is required** (Vault OIDC for Repox). `contents: read` was already required. Workflows without
 `id-token: write` and **fork PRs** (no org Vault OIDC) will fail at credential fetch. That is expected.
-- `**merge_group` is supported.** v2 defaults to incremental `--from-ref` / `--to-ref` on merge-queue
-events (`base_sha`…`head_sha`). Hook failures fail the job; do not ignore them on that trigger.
+- `**merge_group` is supported.** v2 defaults to incremental `--from-ref` / `--to-ref` on merge-queue events
+  (`base_sha`…`head_sha`). Hook failures fail the job; do not ignore them on that trigger.
 - **PRs default to the same diff validation** on `pull_request`. You no longer need `extra-args`.
 - **Branch triggers are supported.** On `push` / `workflow_dispatch` (and other events) the action
 defaults to `--all-files`.
 - `**status` and `logs` outputs are removed.**
 - `ignore-failure` **input is removed.** Hook failures fail the action step.
+- **Bundled `pre-commit` is 4.6.2.** When the action installs the CLI itself (no `pre-commit` on `PATH`), it pins
+  `pre-commit==4.6.2` instead of `3.7.1`. Callers that run `SonarSource/mise-action-wrapper` (or otherwise pre-install
+  `pre-commit`) keep using that version. Hook caches are keyed by the CLI version and the Python interpreter in use.
 
-If the job has already cloned this repository (`origin` owner/repo matches), the action **skips**
-`actions/checkout`. If `--from-ref` / `--to-ref` are missing locally, it runs `git fetch origin`.
-That fetch uses credentials persisted by the caller's `actions/checkout` (`persist-credentials: true`,
-the default). Do not set `persist-credentials: false` unless the needed refs are already local
-(`fetch-depth: 0`).
+If the job has already cloned this repository (`origin` owner/repo matches), the action **skips** `actions/checkout`. If
+`--from-ref` / `--to-ref` are missing locally, it runs `git fetch origin`. That fetch uses credentials persisted by the
+caller's `actions/checkout` (`persist-credentials: true`, the default). Do not set `persist-credentials: false` unless
+the needed refs are already local (`fetch-depth: 0`).
 
 ## Usage
 
 Place a `.pre-commit-config.yaml` at the root of your project.
 
-On pull requests the action checks files changed in the PR. On branch events it checks all files.
-`merge_group` is also supported: the action defaults to incremental `--from-ref` / `--to-ref` on
-that trigger (`base_sha`…`head_sha`).
+On pull requests the action checks files changed in the PR. On branch events it checks all files. `merge_group` is also
+supported: the action defaults to incremental `--from-ref` / `--to-ref` on that trigger (`base_sha`…`head_sha`).
+
+Hook runtimes are not installed by this action. If a hook needs a language or tool on the runner (`language: system` /
+`language: script`, a specific Python for `language_version`, Go, Ruby, and so on), install it in an earlier step (for
+example `SonarSource/mise-action-wrapper`) before this action runs.
 
 ```yaml
 # .github/workflows/pre-commit.yml
@@ -61,10 +66,35 @@ jobs:
       - uses: SonarSource/gh-action_pre-commit@v2
 ```
 
-`fetch-depth: 0` makes `--from-ref` / `--to-ref` resolvable. If checkout is omitted, this action clones
-the repo itself. When checkout is skipped, this action still expects persisted credentials from
-`actions/checkout` so it can fetch missing refs. Pass `extra-args` only when you need different
-pre-commit flags.
+`fetch-depth: 0` makes `--from-ref` / `--to-ref` resolvable. If checkout is omitted, this action clones the repo itself.
+When checkout is skipped, this action still expects persisted credentials from `actions/checkout` so it can fetch
+missing refs. Pass `extra-args` only when you need different pre-commit flags.
+
+### Pre-installed pre-commit
+
+The action looks for `pre-commit` and `python3` on `PATH` independently:
+
+- Skips `setup-python` when `python3` is already on `PATH` and reports a version.
+- Skips the private venv when `pre-commit` is already on `PATH`.
+- If `python3` is missing, installs Python 3.14.7 (including when `pre-commit` is already present, e.g. a mise zipapp).
+- If `pre-commit` is missing, installs `pre-commit==4.6.2` into an action-private venv.
+
+The action does not check that a pre-installed interpreter is new enough for the pre-commit version in use. Callers
+that pre-install both tools are responsible for pairing them. The action's own pin is Python 3.14.7 with
+`pre-commit==4.6.2` (requires Python >= 3.10). A `python` binary without `python3` is not detected; expose the
+interpreter as `python3` (`SonarSource/mise-action-wrapper` does this).
+
+The hook cache is keyed by the CLI version and the interpreter in use (the one already on `PATH`, or 3.14.7 when this
+action installed it). Listing both `pre-commit` and `python` in `mise.toml` (typical after
+`SonarSource/mise-action-wrapper`) skips both installs.
+
+```yaml
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: SonarSource/mise-action-wrapper@v1
+      - uses: SonarSource/gh-action_pre-commit@v2
+```
 
 ## Options
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,26 @@ runs:
     - name: Fetch origin if from-ref/to-ref are missing
       shell: bash
       run: bash "${{ github.action_path }}/scripts/ensure-from-to-refs.sh"
+    - name: Detect pre-commit and python
+      id: detect-pre-commit
+      shell: bash
+      run: |
+        pre_commit_version="$(pre-commit --version 2>/dev/null | awk '{print $2}')" || true
+        python_version="$(python3 --version 2>/dev/null | awk '/^Python / {print $2}')" || true
+        if [ -n "$pre_commit_version" ]; then
+          echo "pre_commit_present=true" | tee -a "$GITHUB_OUTPUT"
+          echo "pre_commit_version=$pre_commit_version" | tee -a "$GITHUB_OUTPUT"
+        else
+          echo "pre_commit_present=false" | tee -a "$GITHUB_OUTPUT"
+          echo "pre_commit_version=4.6.2" | tee -a "$GITHUB_OUTPUT"
+        fi
+        if [ -n "$python_version" ]; then
+          echo "python_present=true" | tee -a "$GITHUB_OUTPUT"
+          echo "python_version=$python_version" | tee -a "$GITHUB_OUTPUT"
+        else
+          echo "python_present=false" | tee -a "$GITHUB_OUTPUT"
+          echo "python_version=3.14.7" | tee -a "$GITHUB_OUTPUT"
+        fi
     - name: Fetch Repox credentials
       uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
       id: repox-secrets
@@ -45,21 +65,41 @@ runs:
         ARTIFACTORY_USERNAME: ${{ fromJSON(steps.repox-secrets.outputs.vault).ARTIFACTORY_USERNAME }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.repox-secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
       run: bash "${{ github.action_path }}/scripts/configure-repox.sh"
+    # Do not nest SonarSource/mise-action-wrapper: it caches ~/.local/share/mise
+    # and would collide with the caller's wrapper. Install python and the CLI
+    # independently when they are missing from PATH.
     - id: setup_python
+      if: steps.detect-pre-commit.outputs.python_present != 'true'
       name: Setup python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
-        python-version: '3.14'
+        python-version: ${{ steps.detect-pre-commit.outputs.python_version }}
+    - name: Cache pre-commit CLI venv
+      uses: SonarSource/gh-action_cache@4e40632e780e11a8bbe9b721985ab22b42847cc4 # 1.7.2
+      if: steps.detect-pre-commit.outputs.pre_commit_present != 'true'
+      id: pre-commit-venv
+      with:
+        path: ${{ runner.temp }}/gh-action-pre-commit-venv
+        key: gh-action-pre-commit-venv|${{ runner.os }}-${{ runner.arch }}|${{ env.pythonLocation || steps.detect-pre-commit.outputs.python_version }}|pre-commit-${{ steps.detect-pre-commit.outputs.pre_commit_version }}
     - name: Setup pre-commit
+      if: steps.detect-pre-commit.outputs.pre_commit_present != 'true' &&
+          steps.pre-commit-venv.outputs.cache-matched-key == ''
+      env:
+        PRE_COMMIT_VERSION: ${{ steps.detect-pre-commit.outputs.pre_commit_version }}
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --quiet pre-commit==3.7.1
+        python3 -m venv "${RUNNER_TEMP}/gh-action-pre-commit-venv"
+        "${RUNNER_TEMP}/gh-action-pre-commit-venv/bin/pip" install --quiet "pre-commit==${PRE_COMMIT_VERSION}"
       shell: bash
-    - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Add pre-commit venv to PATH
+      if: steps.detect-pre-commit.outputs.pre_commit_present != 'true'
+      shell: bash
+      run: echo "${RUNNER_TEMP}/gh-action-pre-commit-venv/bin" >> "$GITHUB_PATH"
+    - name: Cache pre-commit hooks
+      uses: SonarSource/gh-action_cache@4e40632e780e11a8bbe9b721985ab22b42847cc4 # 1.7.2
       id: restore-cache
       with:
-        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(env.CONFIG_PATH) }}
         path: ~/.cache/pre-commit
+        key: pre-commit|${{ runner.os }}-${{ runner.arch }}|${{ steps.detect-pre-commit.outputs.pre_commit_version }}|${{ steps.detect-pre-commit.outputs.python_version }}|${{ hashFiles(env.CONFIG_PATH) }}
     - name: Check existence of .pre-commit-config.yaml file
       run: |
         if [ ! -f "$CONFIG_PATH" ]; then
@@ -75,7 +115,7 @@ runs:
     # that performs a network git op on `origin` will send both the extraheader
     # and URL basic credentials.
     - id: setup-pre-commit-hooks
-      if: steps.restore-cache.outputs.cache-hit != 'true'
+      if: steps.restore-cache.outputs.cache-matched-key == ''
       name: Install pre-commit dependencies
       env:
         GIT_ASKPASS: /bin/true   # allowlisted by pre-commit's no_git_env
@@ -85,12 +125,6 @@ runs:
       run: |
         pre-commit install-hooks --config="$CONFIG_PATH"
       shell: bash
-    - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: steps.restore-cache.outputs.cache-hit != 'true' &&
-          github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-      with:
-        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles(env.CONFIG_PATH) }}
-        path: ~/.cache/pre-commit
     - name: Execute pre-commit
       env:
         GIT_ASKPASS: /bin/true   # allowlisted by pre-commit's no_git_env


### PR DESCRIPTION
BUILD-12512: Prefer a caller-provided `python3` and `pre-commit` on PATH; otherwise install each independently and cache them on S3.

## Summary

- Detect `pre-commit` and `python3` independently. Skip `setup-python` when `python3` is on PATH; skip the private venv when the CLI is on PATH. Detection is `python3` only (no `python` fallback). Callers that pre-install both tools are responsible for pairing a compatible interpreter.
- If `python3` is missing, install Python 3.14.7 even when `pre-commit` is already present (mise zipapps still need an interpreter). If the CLI is missing, install `pre-commit==4.6.2` into an action-private venv.
- Cache the venv and `~/.cache/pre-commit` with `SonarSource/gh-action_cache`. Keys include runner OS/arch, CLI version, the interpreter in use, and (for hooks) the config hash. Do not nest `mise-action-wrapper`.
- Add `it-tests-installs-pre-commit` for the no-mise install path. Document the split skip rules in README/DEV.

## Test plan

- [x] IT workflow passes on `sonar-xs` (including the install-path job)
- [x] Repo pre-commit workflow still passes with `mise-action-wrapper` + this action
- [x] Hook cache keys include OS/arch, CLI version, Python version, and config hash
- [x] A job with only `pre-commit` on PATH still runs `setup-python` if `python3` is missing

Relates to BUILD-12282.